### PR TITLE
Enhanced FortiGate Wazuh Rule Levels Based on Fortinet Log Severity

### DIFF
--- a/0391-fortigate_rules.xml
+++ b/0391-fortigate_rules.xml
@@ -1,9 +1,9 @@
-
 <!--
 -  Fortigate rules
 -  Author: Alexander Tibor Assenheimer - github: alextibor
 -  This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2.
 -  Rules create based on the Fortigate Log Reference from version 7.0.14, 7.2.7, 7.2.8 and 7.4.3
+-  Rule levels based on https://docs.fortinet.com/document/fortigate/7.6.3/fortios-log-message-reference severity mapped with Wazuh rule levels
 -->
 
 <group name="fortigate,">
@@ -13,7688 +13,7688 @@
         <description>Fortigate messages grouped</description>
     </rule>
 
-    <rule id="100011" level="4">
-        <!-- LOGID_ATTCK_ANOMALY_TCP_UDP -->
+    <rule id="100011" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">018432$</field>
         <description>Attack detected by UCP/TCP anomaly</description>
         <group>fortios.event.anomaly,fortios.category.anomaly,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100012" level="4">
-        <!-- LOGID_ATTCK_ANOMALY_ICMP -->
+    <rule id="100012" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">018433$</field>
         <description>Attack detected by ICMP anomaly</description>
         <group>fortios.event.anomaly,fortios.category.anomaly,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100013" level="4">
-        <!-- LOGID_ATTCK_ANOMALY_OTHERS -->
+    <rule id="100013" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">018434$</field>
         <description>Attack detected by other anomaly</description>
         <group>fortios.event.anomaly,fortios.category.anomaly,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100014" level="4">
-        <!-- LOGID_APP_CTRL_IM_BASIC -->
+    <rule id="100014" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028672$</field>
         <description>Application control IM-basic</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100015" level="4">
-        <!-- LOGID_APP_CTRL_IM_BASIC_WITH_STATUS -->
+    <rule id="100015" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028673$</field>
         <description>Application control IM</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100016" level="4">
-        <!-- LOGID_APP_CTRL_IM_BASIC_WITH_COUNT -->
+    <rule id="100016" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028674$</field>
         <description>Application control IM (chat message count)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100017" level="4">
-        <!-- LOGID_APP_CTRL_IM_FILE -->
+    <rule id="100017" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028675$</field>
         <description>Application control IM (file)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100018" level="4">
-        <!-- LOGID_APP_CTRL_IM_CHAT -->
+    <rule id="100018" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028676$</field>
         <description>Application control IM (chat)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100019" level="4">
-        <!-- LOGID_APP_CTRL_IM_CHAT_BLOCK -->
+    <rule id="100019" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028677$</field>
         <description>Application control IM (chat blocked)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100020" level="4">
-        <!-- LOGID_APP_CTRL_IM_BLOCK -->
+    <rule id="100020" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028678$</field>
         <description>Application control IM (blocked)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100021" level="4">
-        <!-- LOGID_APP_CTRL_IPS_PASS -->
+    <rule id="100021" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028704$</field>
         <description>Application control (IPS) (pass)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100022" level="4">
-        <!-- LOGID_APP_CTRL_IPS_BLOCK -->
+    <rule id="100022" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028705$</field>
         <description>Application control (IPS) (block)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100023" level="4">
-        <!-- LOGID_APP_CTRL_IPS_RESET -->
+    <rule id="100023" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028706$</field>
         <description>Application control (IPS) (reset)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100024" level="4">
-        <!-- LOGID_APP_CTRL_SSH_PASS -->
+    <rule id="100024" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028720$</field>
         <description>Application control IM (SSH) (pass)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.information</group>
     </rule>
 
-    <rule id="100025" level="4">
-        <!-- LOGID_APP_CTRL_SSH_BLOCK -->
+    <rule id="100025" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028721$</field>
         <description>Application control IM (SSH) (block)</description>
         <group>fortios.event.app-ctrl,fortios.category.signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100026" level="4">
-        <!-- LOGID_APP_CTRL_PORT_ENF -->
+    <rule id="100026" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028736$</field>
         <description>Application control port enforcement</description>
         <group>fortios.event.app-ctrl,fortios.category.port-violation,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100027" level="4">
-        <!-- LOGID_APP_CTRL_PROTO_ENF -->
+    <rule id="100027" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">028737$</field>
         <description>Application control protocol enforcement</description>
         <group>fortios.event.app-ctrl,fortios.category.protocol-violation,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100028" level="4">
-        <!-- LOG_ID_DLP_WARN -->
+    <rule id="100028" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">024576$</field>
         <description>Data leak detected by specified DLP sensor rule</description>
         <group>fortios.event.dlp,fortios.category.dlp,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100029" level="4">
-        <!-- LOG_ID_DLP_NOTIF -->
+    <rule id="100029" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">024577$</field>
         <description>Data leak detected by specified DLP sensor rule</description>
         <group>fortios.event.dlp,fortios.category.dlp,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100030" level="4">
-        <!-- LOG_ID_DLP_DOC_SOURCE -->
+    <rule id="100030" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">024578$</field>
         <description>DLP fingerprint document source notice</description>
         <group>fortios.event.dlp,fortios.category.dlp-docsource,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100031" level="4">
-        <!-- LOG_ID_DLP_DOC_SOURCE_ERROR -->
+    <rule id="100031" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">024579$</field>
         <description>DLP fingerprint document source error</description>
         <group>fortios.event.dlp,fortios.category.dlp-docsource,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100032" level="4">
-        <!-- LOG_ID_DNS_QUERY -->
+    <rule id="100032" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054000$</field>
         <description>DNS query message</description>
         <group>fortios.event.dns,fortios.category.dns-query,fortios.severity.information</group>
     </rule>
 
-    <rule id="100033" level="4">
-        <!-- LOG_ID_DNS_RESOLV_ERROR -->
+    <rule id="100033" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054200$</field>
         <description>DNS resolution error message</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.error</group>
     </rule>
 
-    <rule id="100034" level="4">
-        <!-- LOG_ID_DNS_URL_FILTER_BLOCK -->
+    <rule id="100034" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054400$</field>
         <description>Domain blocked because it is in the domain-filter list</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100035" level="4">
-        <!-- LOG_ID_DNS_URL_FILTER_ALLOW -->
+    <rule id="100035" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054401$</field>
         <description>Domain allowed because it is in the domain-filter list</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.information</group>
     </rule>
 
-    <rule id="100036" level="4">
-        <!-- LOG_ID_DNS_BOTNET_IP -->
+    <rule id="100036" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054600$</field>
         <description>Domain blocked by DNS botnet C&amp;C (IP)</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100037" level="4">
-        <!-- LOG_ID_DNS_BOTNET_DOMAIN -->
+    <rule id="100037" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054601$</field>
         <description>Domain blocked by DNS botnet C&amp;C (Domain)</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100038" level="4">
-        <!-- LOG_ID_DNS_FTGD_WARNING -->
+    <rule id="100038" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054800$</field>
         <description>FortiGuard rating error warning</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100039" level="4">
-        <!-- LOG_ID_DNS_FTGD_ERROR -->
+    <rule id="100039" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054801$</field>
         <description>FortiGuard rating error occurred</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.error</group>
     </rule>
 
-    <rule id="100040" level="4">
-        <!-- LOG_ID_DNS_FTGD_CAT_ALLOW -->
+    <rule id="100040" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054802$</field>
         <description>Domain is monitored</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100041" level="4">
-        <!-- LOG_ID_DNS_FTGD_CAT_BLOCK -->
+    <rule id="100041" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054803$</field>
         <description>Domain belongs to a denied category in policy</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100042" level="4">
-        <!-- LOG_ID_DNS_SAFE_SEARCH -->
+    <rule id="100042" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054804$</field>
         <description>DNS Safe Search enforced</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100043" level="4">
-        <!-- LOG_ID_DNS_LOCAL -->
+    <rule id="100043" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">054805$</field>
         <description>DNS local query</description>
         <group>fortios.event.dns,fortios.category.dns-response,fortios.severity.information</group>
     </rule>
 
-    <rule id="100044" level="4">
-        <!-- LOGID_ANTISPAM_EMAIL_NOTIF -->
+    <rule id="100044" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020480$</field>
         <description>SPAM notification</description>
         <group>fortios.event.emailfilter,fortios.category.spam,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100045" level="4">
-        <!-- LOGID_EMAIL_GENERAL_NOTIF -->
+    <rule id="100045" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020481$</field>
         <description>Email message</description>
         <group>fortios.event.emailfilter,fortios.category.email,fortios.severity.information</group>
     </rule>
 
-    <rule id="100046" level="4">
-        <!-- LOGID_ANTISPAM_EMAIL_BWORD_NOTIF -->
+    <rule id="100046" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020482$</field>
         <description>Banned word notification</description>
         <group>fortios.event.emailfilter,fortios.category.bannedword,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100047" level="4">
-        <!-- LOGID_ANTISPAM_FTGD_ERR -->
+    <rule id="100047" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020509$</field>
         <description>FortiGuard error message</description>
         <group>fortios.event.emailfilter,fortios.category.ftgd_err,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100048" level="4">
-        <!-- LOGID_ANTISPAM_EMAIL_WEBMAIL_NOTIF -->
+    <rule id="100048" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020510$</field>
         <description>Webmail message</description>
         <group>fortios.event.emailfilter,fortios.category.webmail,fortios.severity.information</group>
     </rule>
 
-    <rule id="100049" level="4">
-        <!-- LOG_ID_DOMAIN_UNRESOLVABLE -->
+    <rule id="100049" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020002$</field>
         <description>Domain name of alert email sender unresolvable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100050" level="4">
-        <!-- LOG_ID_MAIL_SENT_FAIL -->
+    <rule id="100050" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020003$</field>
         <description>Alert email send status failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100051" level="4">
-        <!-- LOG_ID_POLICY_TOO_BIG -->
+    <rule id="100051" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020004$</field>
         <description>Policy too big for installation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100052" level="4">
-        <!-- LOG_ID_PPP_LINK_UP -->
+    <rule id="100052" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020005$</field>
         <description>Modem PPP link up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100053" level="4">
-        <!-- LOG_ID_PPP_LINK_DOWN -->
+    <rule id="100053" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020006$</field>
         <description>Modem PPP link down</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100054" level="4">
-        <!-- LOG_ID_SOCKET_EXHAUSTED -->
+    <rule id="100054" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020007$</field>
         <description>Socket is exhausted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100055" level="4">
-        <!-- LOG_ID_POLICY6_TOO_BIG -->
+    <rule id="100055" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020008$</field>
         <description>IPv6 policy too big for installation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100056" level="4">
-        <!-- LOG_ID_KERNEL_ERROR -->
+    <rule id="100056" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020010$</field>
         <description>Kernel error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100057" level="4">
-        <!-- LOG_ID_MODEM_EXCEED_REDIAL_COUNT -->
+    <rule id="100057" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020016$</field>
         <description>Modem exceeded redial limit</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100058" level="4">
-        <!-- LOG_ID_MODEM_FAIL_TO_OPEN -->
+    <rule id="100058" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020017$</field>
         <description>Modem failed to open</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100059" level="4">
-        <!-- LOG_ID_MODEM_USB_DETECTED -->
+    <rule id="100059" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020020$</field>
         <description>USB modem detected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100060" level="4">
-        <!-- LOG_ID_MAIL_RESENT -->
+    <rule id="100060" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020021$</field>
         <description>Alert email resent</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100061" level="4">
-        <!-- LOG_ID_MODEM_USB_REMOVED -->
+    <rule id="100061" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020022$</field>
         <description>USB modem removed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100062" level="4">
-        <!-- LOG_ID_MODEM_USBLTE_DETECTED -->
+    <rule id="100062" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020023$</field>
         <description>USB LTE modem detected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100063" level="4">
-        <!-- LOG_ID_MODEM_USBLTE_REMOVED -->
+    <rule id="100063" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020024$</field>
         <description>USB LTE modem removed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100064" level="4">
-        <!-- LOG_ID_REPORTD_REPORT_SUCCESS -->
+    <rule id="100064" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020025$</field>
         <description>Report generated successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100065" level="4">
-        <!-- LOG_ID_REPORTD_REPORT_FAILURE -->
+    <rule id="100065" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020026$</field>
         <description>Report generation failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100066" level="4">
-        <!-- LOG_ID_REPORT_RECREATE_DB -->
+    <rule id="100066" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020028$</field>
         <description>Report database recreated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100067" level="4">
-        <!-- LOG_ID_RAD_OUT_OF_MEM -->
+    <rule id="100067" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020031$</field>
         <description>RADVD out of memory</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100068" level="4">
-        <!-- LOG_ID_RAD_NOT_FOUND -->
+    <rule id="100068" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020032$</field>
         <description>RADVD interface not found</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100069" level="4">
-        <!-- LOG_ID_RAD_MOBILE_IPV6 -->
+    <rule id="100069" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020033$</field>
         <description>RADVD mobile IPv6 extensions used</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100070" level="4">
-        <!-- LOG_ID_RAD_IPV6_OUT_OF_RANGE -->
+    <rule id="100070" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020034$</field>
         <description>RADVD mobile IPv6 MinRtrAdvInterval out of range</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100071" level="4">
-        <!-- LOG_ID_RAD_MIN_OUT_OF_RANGE -->
+    <rule id="100071" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020035$</field>
         <description>RADVD MinRtrAdvInterval out of range</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100072" level="4">
-        <!-- LOG_ID_RAD_MAX_OUT_OF_RANGE -->
+    <rule id="100072" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020036$</field>
         <description>RADVD mobile IPv6 MaxRtrAdvInterval out of range</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100073" level="4">
-        <!-- LOG_ID_RAD_MAX_ADV_OUT_OF_RANGE -->
+    <rule id="100073" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020037$</field>
         <description>RADVD MaxRtrAdvInterval out of range</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100074" level="4">
-        <!-- LOG_ID_RAD_MTU_TOO_SMALL -->
+    <rule id="100074" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020039$</field>
         <description>RADVD AdvLinkMTU too small</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100075" level="4">
-        <!-- LOG_ID_RAD_TIME_TOO_SMALL -->
+    <rule id="100075" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020040$</field>
         <description>RADVD AdvReachableTime too small</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100076" level="4">
-        <!-- LOG_ID_RAD_HOP_OUT_OF_RANGE -->
+    <rule id="100076" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020041$</field>
         <description>RADVD AdvCurHopLimit too big</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100077" level="4">
-        <!-- LOG_ID_RAD_DFT_HOP_OUT_OF_RANGE -->
+    <rule id="100077" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020042$</field>
         <description>RADVD AdvCurHopLimit out of range</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100078" level="4">
-        <!-- LOG_ID_RAD_AGENT_OUT_OF_RANGE -->
+    <rule id="100078" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020043$</field>
         <description>RADVD HomeAgentLifetime out of range</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100079" level="4">
-        <!-- LOG_ID_RAD_AGENT_FLAG_NOT_SET -->
+    <rule id="100079" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020044$</field>
         <description>RADVD AdvHomeAgentFlag not set</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100080" level="4">
-        <!-- LOG_ID_RAD_PREFIX_TOO_LONG -->
+    <rule id="100080" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020045$</field>
         <description>RADVD invalid prefix length</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100081" level="4">
-        <!-- LOG_ID_RAD_PREF_TIME_TOO_SMALL -->
+    <rule id="100081" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020046$</field>
         <description>RADVD AdvValidLifetime less than AdvPreferredLifetime</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100082" level="4">
-        <!-- LOG_ID_RAD_INV_ICMPV6_TYPE -->
+    <rule id="100082" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020061$</field>
         <description>RADVD received unwanted ICMPv6 packet</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100083" level="4">
-        <!-- LOG_ID_RAD_INV_ICMPV6_RA_LEN -->
+    <rule id="100083" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020062$</field>
         <description>RADVD received ICMPv6 RA packet with invalid length</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100084" level="4">
-        <!-- LOG_ID_RAD_ICMPV6_NO_SRC_ADDR -->
+    <rule id="100084" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020063$</field>
         <description>RADVD received ICMPv6 RA packet with non-link local source address</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100085" level="4">
-        <!-- LOG_ID_RAD_INV_ICMPV6_RS_LEN -->
+    <rule id="100085" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020064$</field>
         <description>RADVD received ICMPv6 RS packet with invalid length</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100086" level="4">
-        <!-- LOG_ID_RAD_INV_ICMPV6_CODE -->
+    <rule id="100086" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020065$</field>
         <description>RADVD received ICMPv6 RS/RA packet with invalid code</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100087" level="4">
-        <!-- LOG_ID_RAD_INV_ICMPV6_HOP -->
+    <rule id="100087" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020066$</field>
         <description>RADVD received ICMPv6 RS/RA packet with invalid hop limit</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100088" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_HOP -->
+    <rule id="100088" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020067$</field>
         <description>RADVD local AdvCurHopLimit disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100089" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_MGR_FLAG -->
+    <rule id="100089" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020068$</field>
         <description>RADVD local AdvManagedFlag disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100090" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_OTH_FLAG -->
+    <rule id="100090" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020069$</field>
         <description>RADVD local AdvOtherConfigFlag disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100091" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_TIME -->
+    <rule id="100091" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020070$</field>
         <description>RADVD local AdvReachableTime disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100092" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_TIMER -->
+    <rule id="100092" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020071$</field>
         <description>RADVD local AdvRetransTimer disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100093" level="4">
-        <!-- LOG_ID_RAD_EXTRA_DATA -->
+    <rule id="100093" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020072$</field>
         <description>RADVD extra data in RA packet found</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100094" level="4">
-        <!-- LOG_ID_RAD_NO_OPT_DATA -->
+    <rule id="100094" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020073$</field>
         <description>RADVD RA packet option length zero</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100095" level="4">
-        <!-- LOG_ID_RAD_INV_OPT_LEN -->
+    <rule id="100095" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020074$</field>
         <description>RADVD RA packet option length greater than total length</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100096" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_MTU -->
+    <rule id="100096" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020075$</field>
         <description>RADVD local AdvLinkMTU disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100097" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_PREF_TIME -->
+    <rule id="100097" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020077$</field>
         <description>Interface AdvPreferredLifetime on our interface does not agree with a remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100098" level="4">
-        <!-- LOG_ID_RAD_INV_OPT -->
+    <rule id="100098" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020078$</field>
         <description>RADVD found invalid option in RA packet from remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100099" level="4">
-        <!-- LOG_ID_RAD_FAIL_TO_RCV -->
+    <rule id="100099" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020080$</field>
         <description>RADVD receive message failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100100" level="4">
-        <!-- LOG_ID_RAD_INV_HOP -->
+    <rule id="100100" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020081$</field>
         <description>RADVD received invalid IPv6 hop limit</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100101" level="4">
-        <!-- LOG_ID_RAD_INV_PKTINFO -->
+    <rule id="100101" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020082$</field>
         <description>RADVD received invalid IPv6 packet info</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100102" level="4">
-        <!-- LOG_ID_RAD_FAIL_TO_CHECK -->
+    <rule id="100102" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020083$</field>
         <description>RADVD all-routers membership check failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100103" level="4">
-        <!-- LOG_ID_RAD_FAIL_TO_SEND -->
+    <rule id="100103" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020084$</field>
         <description>RADVD send message failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100104" level="4">
-        <!-- LOG_ID_SESSION_CLASH -->
+    <rule id="100104" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020085$</field>
         <description>Session clashed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100105" level="4">
-        <!-- LOG_ID_INTF_LINK_STA_CHG -->
+    <rule id="100105" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020090$</field>
         <description>Interface link status changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100106" level="4">
-        <!-- LOG_ID_INTF_STA_CHG -->
+    <rule id="100106" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020099$</field>
         <description>Interface status changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100107" level="4">
-        <!-- LOG_ID_WEB_CAT_UPDATED -->
+    <rule id="100107" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020100$</field>
         <description>FortiGuard web filter category list updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100108" level="4">
-        <!-- LOG_ID_WEB_LIC_EXPIRE -->
+    <rule id="100108" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020101$</field>
         <description>FortiGuard web filter license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100109" level="4">
-        <!-- LOG_ID_SPAM_LIC_EXPIRE -->
+    <rule id="100109" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020102$</field>
         <description>FortiGuard antispam license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100110" level="4">
-        <!-- LOG_ID_AV_LIC_EXPIRE -->
+    <rule id="100110" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020103$</field>
         <description>FortiGuard antivirus license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100111" level="4">
-        <!-- LOG_ID_IPS_LIC_EXPIRE -->
+    <rule id="100111" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020104$</field>
         <description>FortiGuard IPS license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100112" level="4">
-        <!-- LOG_ID_LOG_UPLOAD_ERR -->
+    <rule id="100112" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020107$</field>
         <description>Log upload error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100113" level="4">
-        <!-- LOG_ID_LOG_UPLOAD_DONE -->
+    <rule id="100113" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020108$</field>
         <description>Log upload completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100114" level="4">
-        <!-- LOG_ID_WEB_LIC_EXPIRED -->
+    <rule id="100114" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020109$</field>
         <description>FortiGuard web filter license expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100115" level="4">
-        <!-- LOG_ID_IPSA_DOWNLOAD_FAIL -->
+    <rule id="100115" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020113$</field>
         <description>IPSA database download failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100116" level="4">
-        <!-- LOG_ID_IPSA_SELFTEST_FAIL -->
+    <rule id="100116" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020114$</field>
         <description>IPSA disabled: self test failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100117" level="4">
-        <!-- LOG_ID_IPSA_STATUSUPD_FAIL -->
+    <rule id="100117" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020115$</field>
         <description>IPSA driver update failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100118" level="4">
-        <!-- LOG_ID_SPAM_LIC_EXPIRED -->
+    <rule id="100118" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020116$</field>
         <description>FortiGuard antispam license expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100119" level="4">
-        <!-- LOG_ID_AV_LIC_EXPIRED -->
+    <rule id="100119" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020117$</field>
         <description>FortiGuard antivirus license expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100120" level="4">
-        <!-- LOG_ID_WEBF_STATUS_REACH -->
+    <rule id="100120" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020118$</field>
         <description>FortiGuard webfilter reachable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100121" level="4">
-        <!-- LOG_ID_WEBF_STATUS_UNREACH -->
+    <rule id="100121" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020119$</field>
         <description>FortiGuard webfilter unreachable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100122" level="4">
-        <!-- LOG_ID_FMGC_LIC_EXPIRE -->
+    <rule id="100122" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020120$</field>
         <description>FortiManager Cloud license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100123" level="4">
-        <!-- LOG_ID_FAZC_LIC_EXPIRE -->
+    <rule id="100123" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020121$</field>
         <description>FortiAnalyzer Cloud license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100124" level="4">
-        <!-- LOG_ID_SWNO_LIC_EXPIRE -->
+    <rule id="100124" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020122$</field>
         <description>SD-WAN Overlay Controller license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100125" level="4">
-        <!-- LOG_ID_SWNM_LIC_EXPIRE -->
+    <rule id="100125" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020123$</field>
         <description>SD-WAN Monitoring license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100126" level="4">
-        <!-- LOG_ID_VMLS_LIC_EXPIRE -->
+    <rule id="100126" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020124$</field>
         <description>VM-S license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100127" level="4">
-        <!-- LOG_ID_SFAS_LIC_EXPIRE -->
+    <rule id="100127" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020125$</field>
         <description>Security Rating license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100128" level="4">
-        <!-- LOG_ID_IPMC_LIC_EXPIRE -->
+    <rule id="100128" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020126$</field>
         <description>IPAM Controller license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100129" level="4">
-        <!-- LOG_ID_IOTH_LIC_EXPIRE -->
+    <rule id="100129" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020127$</field>
         <description>IoT device identification license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100130" level="4">
-        <!-- LOG_ID_FSAC_LIC_EXPIRE -->
+    <rule id="100130" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020128$</field>
         <description>FortiSandbox Cloud license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100131" level="4">
-        <!-- LOG_ID_AFAC_LIC_EXPIRE -->
+    <rule id="100131" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020129$</field>
         <description>FortiAnalyzer Cloud premium license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100132" level="4">
-        <!-- LOG_ID_EMSC_ACC_LIC_EXPIRE -->
+    <rule id="100132" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020130$</field>
         <description>FortiClient EMS Cloud license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100133" level="4">
-        <!-- LOG_ID_FMGC_ACC_LIC_EXPIRE -->
+    <rule id="100133" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020131$</field>
         <description>FortiManager Cloud Account Level license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100134" level="4">
-        <!-- LOG_ID_FSAP_ACC_LIC_EXPIRE -->
+    <rule id="100134" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020132$</field>
         <description>FortiSandbox Cloud Account Level license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100135" level="4">
-        <!-- LOG_ID_FIREWALL_POLICY_EXPIRE -->
+    <rule id="100135" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020133$</field>
         <description>Firewall policy expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100136" level="4">
-        <!-- LOG_ID_FIREWALL_POLICY_EXPIRED -->
+    <rule id="100136" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020134$</field>
         <description>Firewall policy expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100137" level="4">
-        <!-- LOG_ID_FAIS_LIC_EXPIRE -->
+    <rule id="100137" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020135$</field>
         <description>FortiGuard AI-Based Sandbox Service license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100138" level="4">
-        <!-- LOG_ID_FIPS_SELF_TEST -->
+    <rule id="100138" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020200$</field>
         <description>FIPS CC self-test initiated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100139" level="4">
-        <!-- LOG_ID_FIPS_SELF_ALL_TEST -->
+    <rule id="100139" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020201$</field>
         <description>FIPS ALL CC self-tests initiated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100140" level="4">
-        <!-- LOG_ID_DISK_FORMAT_ERROR -->
+    <rule id="100140" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020202$</field>
         <description>Disk partitioning or formatting Error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100141" level="4">
-        <!-- LOG_ID_DAEMON_SHUTDOWN -->
+    <rule id="100141" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020203$</field>
         <description>Daemon shutdown</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100142" level="4">
-        <!-- LOG_ID_DAEMON_START -->
+    <rule id="100142" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020204$</field>
         <description>Daemon started</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100143" level="4">
-        <!-- LOG_ID_DISK_FORMAT_REQ -->
+    <rule id="100143" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020205$</field>
         <description>Format disk requested</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100144" level="4">
-        <!-- LOG_ID_DISK_SCAN_REQ -->
+    <rule id="100144" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020206$</field>
         <description>Scan disk requested</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100145" level="4">
-        <!-- LOG_ID_RAD_MISMATCH_VALID_TIME -->
+    <rule id="100145" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020207$</field>
         <description>RADVD local AdvValidLifetime disagrees with remote site</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100146" level="4">
-        <!-- LOG_ID_ZOMBIE_DAEMON_CLEANUP -->
+    <rule id="100146" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020208$</field>
         <description>Zombie daemon cleanup</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100147" level="4">
-        <!-- LOG_ID_DISK_UNAVAIL -->
+    <rule id="100147" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020209$</field>
         <description>Disk unavailable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100148" level="4">
-        <!-- LOG_ID_DISK_TRIM_START -->
+    <rule id="100148" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020210$</field>
         <description>SSD TRIM started</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100149" level="4">
-        <!-- LOG_ID_DISK_TRIM_END -->
+    <rule id="100149" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020211$</field>
         <description>SSD TRIM finished</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100150" level="4">
-        <!-- LOG_ID_DISK_SCAN_NEEDED -->
+    <rule id="100150" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020212$</field>
         <description>Disk scan is needed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100151" level="4">
-        <!-- LOG_ID_DISK_LOG_CORRUPTED -->
+    <rule id="100151" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020213$</field>
         <description>Log file on disk is corrupted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100152" level="4">
-        <!-- LOG_ID_LOCAL_OUT_IOC -->
+    <rule id="100152" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020214$</field>
         <description>Locally generated traffic goes to IoC location</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100153" level="4">
-        <!-- LOGID_EVENT_SHAPER_OUTBOUND_MAXED_OUT -->
+    <rule id="100153" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020220$</field>
         <description>Outbound bandwidth rate exceeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100154" level="4">
-        <!-- LOGID_EVENT_SHAPER_INBOUND_MAXED_OUT -->
+    <rule id="100154" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020221$</field>
         <description>Inbound bandwidth rate exceeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100155" level="4">
-        <!-- LOG_ID_SYS_SECURITY_WRITE_VIOLATION -->
+    <rule id="100155" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020230$</field>
         <description>Write Permission Violation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100156" level="4">
-        <!-- LOG_ID_SYS_SECURITY_HARDLINK_VIOLATION -->
+    <rule id="100156" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020231$</field>
         <description>Hard Link Creation Violation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100157" level="4">
-        <!-- LOG_ID_SYS_SECURITY_LOAD_MODULE_VIOLATION -->
+    <rule id="100157" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020232$</field>
         <description>Load Kernel/Kernel Module/Firmware Violation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100158" level="4">
-        <!-- LOG_ID_SYS_SECURITY_FILE_HASH_MISSING -->
+    <rule id="100158" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020233$</field>
         <description>Integrity check of Run/loading Excutable File failed without Integrity measure</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100159" level="4">
-        <!-- LOG_ID_SYS_SECURITY_FILE_HASH_MISMATCH -->
+    <rule id="100159" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020234$</field>
         <description>Integrity check of Run/loading Excutable File failed with mismatched measure</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100160" level="4">
-        <!-- LOG_ID_SYS_SECURITY_MOUNT_VIOLATION -->
+    <rule id="100160" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020235$</field>
         <description>Filesystem Mount Violation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100161" level="4">
-        <!-- LOG_ID_BGP_NB_STAT_CHG -->
+    <rule id="100161" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020300$</field>
         <description>BGP neighbor status changed</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100162" level="4">
-        <!-- LOG_ID_VZ_LOG_INFO -->
+    <rule id="100162" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020301$</field>
         <description>Routing log information</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.information</group>
     </rule>
 
-    <rule id="100163" level="4">
-        <!-- LOG_ID_OSPF_NB_STAT_CHG -->
+    <rule id="100163" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020302$</field>
         <description>OSPF neighbor status changed</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100164" level="4">
-        <!-- LOG_ID_OSPF6_NB_STAT_CHG -->
+    <rule id="100164" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020303$</field>
         <description>OSPF6 neighbor status changed</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100165" level="4">
-        <!-- LOG_ID_VZ_LOG_WARNING -->
+    <rule id="100165" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020304$</field>
         <description>Routing log warning</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100166" level="4">
-        <!-- LOG_ID_VZ_LOG_CRITICAL -->
+    <rule id="100166" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020305$</field>
         <description>Routing log critical event</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100167" level="4">
-        <!-- LOG_ID_VZ_LOG_ERROR -->
+    <rule id="100167" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020306$</field>
         <description>Routing log error</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.error</group>
     </rule>
 
-    <rule id="100168" level="4">
-        <!-- LOG_ID_ROUTER_CLEAR -->
+    <rule id="100168" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020401$</field>
         <description>Router cleared</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100169" level="4">
-        <!-- LOG_ID_INV_PKT_LEN -->
+    <rule id="100169" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022000$</field>
         <description>Packet length mismatch</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100170" level="4">
-        <!-- LOG_ID_UNSUPPORTED_PROT_VER -->
+    <rule id="100170" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022001$</field>
         <description>Protocol version unsupported</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100171" level="4">
-        <!-- LOG_ID_INV_REQ_TYPE -->
+    <rule id="100171" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022002$</field>
         <description>Request type not supported</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100172" level="4">
-        <!-- LOG_ID_FAIL_SET_SIG_HANDLER -->
+    <rule id="100172" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022003$</field>
         <description>Signal handler setup failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100173" level="4">
-        <!-- LOG_ID_FAIL_CREATE_SOCKET -->
+    <rule id="100173" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022004$</field>
         <description>Socket creation failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100174" level="4">
-        <!-- LOG_ID_FAIL_CREATE_SOCKET_RETRY -->
+    <rule id="100174" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022005$</field>
         <description>Socket creation retry failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100175" level="4">
-        <!-- LOG_ID_FAIL_REG_CMDB_EVENT -->
+    <rule id="100175" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022006$</field>
         <description>Registration for CMDB events failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100176" level="4">
-        <!-- LOG_ID_FAIL_FIND_AV_PROFILE -->
+    <rule id="100176" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022009$</field>
         <description>AntiVirus profile not found</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100177" level="4">
-        <!-- LOG_ID_SENDTO_FAIL -->
+    <rule id="100177" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022010$</field>
         <description>URL filter packet send failure</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100178" level="4">
-        <!-- LOG_ID_ENTER_MEM_CONSERVE_MODE -->
+    <rule id="100178" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022011$</field>
         <description>Memory conserve mode entered</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100179" level="4">
-        <!-- LOG_ID_LEAVE_MEM_CONSERVE_MODE -->
+    <rule id="100179" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022012$</field>
         <description>Memory conserve mode exited</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100180" level="4">
-        <!-- LOG_ID_IPPOOLPBA_BLOCK_EXHAUSTED -->
+    <rule id="100180" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022013$</field>
         <description>IP pool PBA block exhausted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100181" level="4">
-        <!-- LOG_ID_IPPOOLPBA_NATIP_EXHAUSTED -->
+    <rule id="100181" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022014$</field>
         <description>IP pool PBA NAT IP exhausted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100182" level="4">
-        <!-- LOG_ID_IPPOOLPBA_CREATE -->
+    <rule id="100182" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022015$</field>
         <description>IP pool PBA created</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100183" level="4">
-        <!-- LOG_ID_IPPOOLPBA_DEALLOCATE -->
+    <rule id="100183" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022016$</field>
         <description>Deallocate IP pool PBA</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100184" level="4">
-        <!-- LOG_ID_EXCEED_GLOB_RES_LIMIT -->
+    <rule id="100184" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022017$</field>
         <description>Global resource limit exceeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100185" level="4">
-        <!-- LOG_ID_EXCEED_VD_RES_LIMIT -->
+    <rule id="100185" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022018$</field>
         <description>VDOM resource limit exceeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100186" level="4">
-        <!-- LOG_ID_LOGRATE_OVER_LIMIT -->
+    <rule id="100186" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022019$</field>
         <description>Log rate limit exceeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100187" level="4">
-        <!-- LOG_ID_FAIL_CREATE_HA_SOCKET -->
+    <rule id="100187" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022020$</field>
         <description>HA socket creation failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100188" level="4">
-        <!-- LOG_ID_FAIL_CREATE_HA_SOCKET_RETRY -->
+    <rule id="100188" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022021$</field>
         <description>UDP socket creation to relay URL request failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100189" level="4">
-        <!-- LOG_ID_SUCCESS_CSF_LOG_SYNC_CONFIG_CHANGED -->
+    <rule id="100189" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022031$</field>
         <description>Settings modified by Security Fabric service</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100190" level="4">
-        <!-- LOG_ID_CSF_LOOP_FOUND -->
+    <rule id="100190" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022032$</field>
         <description>Looped configuration in Security Fabric service</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100191" level="4">
-        <!-- LOG_ID_CSF_UPSTREAM_SN_CHANGED -->
+    <rule id="100191" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022035$</field>
         <description>Serial number of upstream is changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100192" level="4">
-        <!-- LOG_ID_CSF_FGT_CONNECTED -->
+    <rule id="100192" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022036$</field>
         <description>Connection with Security Fabric member established and authorized.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100193" level="4">
-        <!-- LOG_ID_CSF_FGT_DISCONNECTED -->
+    <rule id="100193" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022037$</field>
         <description>Connection with authorized Security Fabric member terminated.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100194" level="4">
-        <!-- LOG_ID_CSF_GLOBAL_SYNC_FAILED -->
+    <rule id="100194" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022038$</field>
         <description>Synchronization of global object failed.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100195" level="4">
-        <!-- LOG_ID_CSF_GLOBAL_SYNC_REPORT -->
+    <rule id="100195" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022039$</field>
         <description>Synchronization of global object report.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100196" level="4">
-        <!-- LOG_ID_CSF_DEVICE_JOIN -->
+    <rule id="100196" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022040$</field>
         <description>Device joined the Security Fabric.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100197" level="4">
-        <!-- LOG_ID_CSF_DEVICE_LEAVE -->
+    <rule id="100197" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022041$</field>
         <description>Device left the Security Fabric.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100198" level="4">
-        <!-- LOG_ID_CSF_DEVICE_UPDATE -->
+    <rule id="100198" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022042$</field>
         <description>Device in the Security Fabric was updated.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100199" level="4">
-        <!-- LOG_ID_CSF_NEW_AUTH_REQ -->
+    <rule id="100199" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022043$</field>
         <description>An authorization request was added.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100200" level="4">
-        <!-- LOG_ID_CSF_UPDATE_AUTH_REQ -->
+    <rule id="100200" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022044$</field>
         <description>An authorization request was updated.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100201" level="4">
-        <!-- LOG_ID_CSF_REMOVE_AUTH_REQ -->
+    <rule id="100201" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022045$</field>
         <description>An authorization request was removed.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100202" level="4">
-        <!-- LOG_ID_CSF_ROLE_CHANGE -->
+    <rule id="100202" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022046$</field>
         <description>Device's authorization privilege changed.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100203" level="4">
-        <!-- LOG_ID_CSF_FILE_MEM_USAGE -->
+    <rule id="100203" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022047$</field>
         <description>CSF daemon files memory usage warning.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100204" level="4">
-        <!-- LOG_ID_CSF_ADVPN_SYNC -->
+    <rule id="100204" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022048$</field>
         <description>Fabric ADVPN configuration synchronized from root.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100205" level="4">
-        <!-- LOG_ID_CSF_DAEMON_CLOSE -->
+    <rule id="100205" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022049$</field>
         <description>Daemon csfd has closed.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100206" level="4">
-        <!-- LOG_ID_IPAMD_ADDRESS_ALLOCATED -->
+    <rule id="100206" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022050$</field>
         <description>Address allocated by FortiIPAM and applied to an interface</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100207" level="4">
-        <!-- LOG_ID_IPAMD_ADDRESS_SET_FAILED -->
+    <rule id="100207" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022051$</field>
         <description>Address received from FortiIPAM could not be applied to the interface</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100208" level="4">
-        <!-- LOG_ID_IPAMD_ADDRESS_INVALIDATED -->
+    <rule id="100208" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022052$</field>
         <description>FortiIPAM indicated that the address was no longer allocated to the interface</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100209" level="4">
-        <!-- LOG_ID_IPAMD_VALIDATION_COMPLETE -->
+    <rule id="100209" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022053$</field>
         <description>Startup validation of IPAM addresses was completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100210" level="4">
-        <!-- LOG_ID_IPAMSD_ADDRESS_ALLOCATED -->
+    <rule id="100210" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022060$</field>
         <description>Address allocated to IPAM interface</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100211" level="4">
-        <!-- LOG_ID_IPAMSD_ADDRESS_FREED -->
+    <rule id="100211" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022061$</field>
         <description>Address freed by IPAM interface</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100212" level="4">
-        <!-- LOG_ID_IPAMSD_FLAG_CONFLICT -->
+    <rule id="100212" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022062$</field>
         <description>Flag IPAM entry as conflict</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100213" level="4">
-        <!-- LOG_ID_IPAMSD_UNFLAG_CONFLICT -->
+    <rule id="100213" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022063$</field>
         <description>Unflag IPAM entry as conflict</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100214" level="4">
-        <!-- LOG_ID_PROVISION_LATEST_SUCCEEDED -->
+    <rule id="100214" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022080$</field>
         <description>Provisioning of latest firmware was completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100215" level="4">
-        <!-- LOG_ID_PROVISION_LATEST_FAILED -->
+    <rule id="100215" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022081$</field>
         <description>Provisioning of latest firmware failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100216" level="4">
-        <!-- LOG_ID_DEVICE_UPGRADE_SUCCEEDED -->
+    <rule id="100216" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022085$</field>
         <description>A device upgrade was completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100217" level="4">
-        <!-- LOG_ID_DEVICE_UPGRADE_FAILED -->
+    <rule id="100217" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022086$</field>
         <description>A device upgrade failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100218" level="4">
-        <!-- LOG_ID_FEDERATED_UPGRADE_CANCELLED -->
+    <rule id="100218" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022090$</field>
         <description>A federated upgrade was cancelled due to the CSF tree not being ready</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100219" level="4">
-        <!-- LOG_ID_FEDERATED_UPGRADE_SUCCEEDED -->
+    <rule id="100219" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022091$</field>
         <description>A federated upgrade was completed successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100220" level="4">
-        <!-- LOG_ID_FEDERATED_UPGRADE_FAILED -->
+    <rule id="100220" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022092$</field>
         <description>A federated upgrade failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100221" level="4">
-        <!-- LOG_ID_FEDERATED_UPGRADE_STEP_COMPLETE -->
+    <rule id="100221" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022093$</field>
         <description>A step in a multi-step federated upgrade was completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100222" level="4">
-        <!-- LOG_ID_FEDERATED_UPGRADE_ROOT_COMPLETED -->
+    <rule id="100222" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022094$</field>
         <description>A federated upgrade was completed by the root FortiGate</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100223" level="4">
-        <!-- LOG_ID_FEDERATED_UPGRADE_ROOT_NOT_COMPLETED -->
+    <rule id="100223" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022095$</field>
         <description>A federated upgrade could not be completed by the root FortiGate</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100224" level="4">
-        <!-- LOG_ID_QUAR_DROP_TRAN_JOB -->
+    <rule id="100224" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022100$</field>
         <description>Files dropped by quarantine daemon</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100225" level="4">
-        <!-- LOG_ID_QUAR_DROP_TLL_JOB -->
+    <rule id="100225" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022101$</field>
         <description>Files dropped due to poor network connection</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100226" level="4">
-        <!-- LOG_ID_LOG_DISK_FAILURE -->
+    <rule id="100226" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022102$</field>
         <description>Log disk failure imminent</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100227" level="4">
-        <!-- LOG_ID_QUAR_LIMIT_REACHED -->
+    <rule id="100227" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022103$</field>
         <description>Sandbox limit reached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100228" level="4">
-        <!-- LOG_ID_POWER_RESTORE -->
+    <rule id="100228" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022104$</field>
         <description>Power supply restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100229" level="4">
-        <!-- LOG_ID_POWER_FAILURE -->
+    <rule id="100229" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022105$</field>
         <description>Power supply failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100230" level="4">
-        <!-- LOG_ID_POWER_OPTIONAL_NOT_DETECTED -->
+    <rule id="100230" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022106$</field>
         <description>Optional power supply not detected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100231" level="4">
-        <!-- LOG_ID_VOLT_ANOM -->
+    <rule id="100231" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022107$</field>
         <description>Voltage anomaly</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100232" level="4">
-        <!-- LOG_ID_FAN_ANOM -->
+    <rule id="100232" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022108$</field>
         <description>Fan anomaly</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100233" level="4">
-        <!-- LOG_ID_TEMP_TOO_HIGH -->
+    <rule id="100233" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022109$</field>
         <description>Temperature too high</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100234" level="4">
-        <!-- LOG_ID_SPARE_BLOCK_LOW -->
+    <rule id="100234" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022110$</field>
         <description>Spare blocks availability low</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100235" level="4">
-        <!-- LOG_ID_PSU_ACTION_FPC_DOWN -->
+    <rule id="100235" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022111$</field>
         <description>FPC down due to PSU action</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100236" level="4">
-        <!-- LOG_ID_PSU_ACTION_FPC_UP -->
+    <rule id="100236" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022112$</field>
         <description>FPC up due to PSU action</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100237" level="4">
-        <!-- LOG_ID_FNBAM_FAILURE -->
+    <rule id="100237" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022113$</field>
         <description>Authentication error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100238" level="4">
-        <!-- LOG_ID_POWER_FAILURE_WARNING -->
+    <rule id="100238" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022114$</field>
         <description>Power supply failed warning</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100239" level="4">
-        <!-- LOG_ID_POWER_RESTORE_NOTIF -->
+    <rule id="100239" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022115$</field>
         <description>Power supply restored notification</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100240" level="4">
-        <!-- LOG_ID_POWER_REDUNDANCY_DEGRADE -->
+    <rule id="100240" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022116$</field>
         <description>Power Supply Redundancy Degrade</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100241" level="4">
-        <!-- LOG_ID_POWER_REDUNDANCY_FAILURE -->
+    <rule id="100241" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022117$</field>
         <description>Power Supply Redundancy Lost</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100242" level="4">
-        <!-- LOG_ID_VOLT_NOM -->
+    <rule id="100242" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022150$</field>
         <description>Voltage normal</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100243" level="4">
-        <!-- LOG_ID_FAN_NOM -->
+    <rule id="100243" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022151$</field>
         <description>Fan normal</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100244" level="4">
-        <!-- LOG_ID_TEMP_TOO_LOW -->
+    <rule id="100244" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022152$</field>
         <description>Temperature too low</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100245" level="4">
-        <!-- LOG_ID_TEMP_NORM -->
+    <rule id="100245" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022153$</field>
         <description>Temperature normal</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100246" level="4">
-        <!-- LOG_ID_AUTO_UPT_CERT -->
+    <rule id="100246" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022200$</field>
         <description>Certificate will be auto-updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100247" level="4">
-        <!-- LOG_ID_AUTO_GEN_CERT -->
+    <rule id="100247" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022201$</field>
         <description>Certificate will be auto-regenerated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100248" level="4">
-        <!-- LOG_ID_AUTO_GEN_CERT_FAIL -->
+    <rule id="100248" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022203$</field>
         <description>Certificate failed to auto-generate</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100249" level="4">
-        <!-- LOG_ID_AUTO_GEN_CERT_PENDING -->
+    <rule id="100249" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022204$</field>
         <description>Certificate pending to auto-generate</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100250" level="4">
-        <!-- LOG_ID_AUTO_GEN_CERT_SUCC -->
+    <rule id="100250" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022205$</field>
         <description>Certificate succeed to auto-generate</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100251" level="4">
-        <!-- LOG_ID_CRL_EXPIRED -->
+    <rule id="100251" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022206$</field>
         <description>CRL is expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100252" level="4">
-        <!-- LOG_ID_CERT_EXPIRE_WARNING -->
+    <rule id="100252" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022207$</field>
         <description>Certificate will expire soon</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100253" level="4">
-        <!-- LOG_ID_EXT_RESOURCE -->
+    <rule id="100253" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022220$</field>
         <description>Threat feed updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100254" level="4">
-        <!-- LOG_ID_EXT_RESOURCE_FAIL -->
+    <rule id="100254" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022221$</field>
         <description>Threat feed update failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100255" level="4">
-        <!-- LOG_ID_EXT_RESOURCE_LOAD -->
+    <rule id="100255" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022222$</field>
         <description>Threat feed loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100256" level="4">
-        <!-- LOG_ID_EXT_RESOURCE_DEBUG -->
+    <rule id="100256" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022223$</field>
         <description>Threat feed debug</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100257" level="4">
-        <!-- LOG_ID_IPS_FAIL_OPEN -->
+    <rule id="100257" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022700$</field>
         <description>IPS session scan paused</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100258" level="4">
-        <!-- LOG_ID_IPS_FAIL_OPEN_END -->
+    <rule id="100258" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022701$</field>
         <description>IPS session scan resumed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100259" level="4">
-        <!-- LOG_ID_SCAN_SERV_FAIL -->
+    <rule id="100259" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022800$</field>
         <description>Scan services session failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100260" level="4">
-        <!-- LOG_ID_ENTER_FD_CONSERVE_MODE -->
+    <rule id="100260" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022802$</field>
         <description>File descriptor conserve mode entered</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100261" level="4">
-        <!-- LOG_ID_LEAVE_FD_CONSERVE_MODE -->
+    <rule id="100261" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022803$</field>
         <description>File descriptor conserve mode exited</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100262" level="4">
-        <!-- LOG_ID_LIC_STATUS_CHG -->
+    <rule id="100262" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022804$</field>
         <description>License status changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100263" level="4">
-        <!-- LOG_ID_FAIL_TO_VALIDATE_LIC -->
+    <rule id="100263" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022805$</field>
         <description>License validation failure</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100264" level="4">
-        <!-- LOG_ID_DUP_LIC -->
+    <rule id="100264" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022806$</field>
         <description>Duplicate license detected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100265" level="4">
-        <!-- LOG_ID_VDOM_LIC -->
+    <rule id="100265" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022807$</field>
         <description>VDOM license status changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100266" level="4">
-        <!-- LOG_ID_LIC_EXPIRE -->
+    <rule id="100266" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022808$</field>
         <description>VM license expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100267" level="4">
-        <!-- LOG_ID_LIC_WILL_EXPIRE -->
+    <rule id="100267" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022809$</field>
         <description>VM license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100268" level="4">
-        <!-- LOG_ID_SCANUNIT_ERROR_BLOCK -->
+    <rule id="100268" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022810$</field>
         <description>Scan error - traffic blocked</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100269" level="4">
-        <!-- LOG_ID_SCANUNIT_ERROR_PASS -->
+    <rule id="100269" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022811$</field>
         <description>Scan error - traffic passed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100270" level="4">
-        <!-- LOG_ID_SCANUNIT_AVENG_RELOAD -->
+    <rule id="100270" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022812$</field>
         <description>Scanunit is reloading AV engine</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100271" level="4">
-        <!-- LOG_ID_SCANUNIT_AVDB_RELOAD -->
+    <rule id="100271" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022813$</field>
         <description>Scanunit reloaded AV Database</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100272" level="4">
-        <!-- LOG_ID_SCANUNIT_AVDB_RELOAD_ERROR -->
+    <rule id="100272" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022814$</field>
         <description>Scanunit AV Database reload error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100273" level="4">
-        <!-- LOG_ID_SCANUNIT_AVDB_LOAD -->
+    <rule id="100273" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022815$</field>
         <description>Scanunit loaded AV Database</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100274" level="4">
-        <!-- LOG_ID_SCANUNIT_AVDB_LOAD_ERROR -->
+    <rule id="100274" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022816$</field>
         <description>Scanunit AV Database load error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100275" level="4">
-        <!-- LOG_ID_USER_QUARANTINE_MAC_ADD -->
+    <rule id="100275" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022850$</field>
         <description>User quarantine MAC added</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100276" level="4">
-        <!-- LOG_ID_USER_QUARANTINE_MAC_DELETE -->
+    <rule id="100276" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022851$</field>
         <description>User quarantine MAC deleted</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100277" level="4">
-        <!-- LOG_ID_USER_QUARANTINE_MAC_BOUNCE_PORT_HIT -->
+    <rule id="100277" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022852$</field>
         <description>User quarantine MAC bounce port hit</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100278" level="4">
-        <!-- LOG_ID_USER_QUARANTINE_MAC_BOUNCE_PORT_MISS -->
+    <rule id="100278" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022853$</field>
         <description>User quarantine MAC bounce port miss</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100279" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_ADD -->
+    <rule id="100279" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022861$</field>
         <description>NAC device addition</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100280" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_DELETE -->
+    <rule id="100280" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022862$</field>
         <description>NAC device deletion</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100281" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_MODIFY -->
+    <rule id="100281" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022863$</field>
         <description>NAC device modify</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100282" level="4">
-        <!-- LOG_ID_FLPOLD_DPP_ADD -->
+    <rule id="100282" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022864$</field>
         <description>DPP device addition</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100283" level="4">
-        <!-- LOG_ID_FLPOLD_DPP_DELETE -->
+    <rule id="100283" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022865$</field>
         <description>DPP device deletion</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100284" level="4">
-        <!-- LOG_ID_FLPOLD_DPP_MODIFY -->
+    <rule id="100284" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022866$</field>
         <description>DPP device modify</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100285" level="4">
-        <!-- LOG_ID_FLPOLD_DPP_INTF_TAGS_ADD -->
+    <rule id="100285" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022867$</field>
         <description>DPP interface tags add</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100286" level="4">
-        <!-- LOG_ID_FLPOLD_DPP_INTF_TAGS_DELETE -->
+    <rule id="100286" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022868$</field>
         <description>DPP interface tags delete</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100287" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_DYNAMIC_ADDRESS_ADD -->
+    <rule id="100287" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022869$</field>
         <description>NAC device dynamic address addition</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100288" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_DYNAMIC_ADDRESS_DELETE -->
+    <rule id="100288" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022870$</field>
         <description>NAC device dynamic address deletion</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100289" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_MAC_CACHE_SYNC -->
+    <rule id="100289" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022871$</field>
         <description>NAC MAC cache sync</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100290" level="4">
-        <!-- LOG_ID_FLPOLD_NAC_MAX_ERROR -->
+    <rule id="100290" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022872$</field>
         <description>NAC device Max Limit Error</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100291" level="4">
-        <!-- LOG_ID_FLPOLD_DPP_MAX_ERROR -->
+    <rule id="100291" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022873$</field>
         <description>DPP device Max Limit Error</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100292" level="4">
-        <!-- LOG_ID_FORTILINKD -->
+    <rule id="100292" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022890$</field>
         <description>Switch-Controller Daemon Log (Notification)</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100293" level="4">
-        <!-- LOG_ID_FLCFGD_SYNC_ERROR -->
+    <rule id="100293" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022891$</field>
         <description>Switch-Controller Switch Sync Error</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.error</group>
     </rule>
 
-    <rule id="100294" level="4">
-        <!-- LOG_ID_FLCFGD_SYNC_COMPLETE -->
+    <rule id="100294" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022892$</field>
         <description>Switch-Controller Switch Sync Complete</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100295" level="4">
-        <!-- LOG_ID_FLCFGD_SYNC_STATE -->
+    <rule id="100295" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022893$</field>
         <description>Switch-Controller Switch Sync State</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100296" level="4">
-        <!-- LOG_ID_FLCFGD_UPGRADE_ERROR -->
+    <rule id="100296" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022894$</field>
         <description>Switch-Controller Switch Upgrade Error</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.error</group>
     </rule>
 
-    <rule id="100297" level="4">
-        <!-- LOG_ID_FLCFGD_UPGRADE_STATUS -->
+    <rule id="100297" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022895$</field>
         <description>Switch-Controller Switch Upgrade Status</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100298" level="4">
-        <!-- LOG_ID_FORTILINKD_CRITICAL -->
+    <rule id="100298" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022896$</field>
         <description>Switch-Controller Daemon Log (Critical)</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100299" level="4">
-        <!-- LOG_ID_FORTILINKD_SPLIT_PORT_INFO -->
+    <rule id="100299" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022897$</field>
         <description>Switch-controller split-port related configuration change detected</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100300" level="4">
-        <!-- LOG_ID_CAPUTP_SESSION -->
+    <rule id="100300" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022900$</field>
         <description>CAPUTP session status</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100301" level="4">
-        <!-- LOG_ID_FAZ_CON -->
+    <rule id="100301" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022901$</field>
         <description>FortiAnalyzer connection up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100302" level="4">
-        <!-- LOG_ID_FAZ_DISCON -->
+    <rule id="100302" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022902$</field>
         <description>FortiAnalyzer connection down</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100303" level="4">
-        <!-- LOG_ID_FAZ_CON_ERR -->
+    <rule id="100303" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022903$</field>
         <description>FortiAnalyzer connection failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100304" level="4">
-        <!-- LOG_ID_CAPUTP_SESSION_NOTIF -->
+    <rule id="100304" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022904$</field>
         <description>CAPUTP session status notification</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100305" level="4">
-        <!-- LOG_ID_FDS_SRV_ERRCON -->
+    <rule id="100305" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022912$</field>
         <description>FortiGate Cloud server connection failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100306" level="4">
-        <!-- LOG_ID_FDS_SRV_DISCON -->
+    <rule id="100306" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022913$</field>
         <description>FortiGate Cloud server disconnected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100307" level="4">
-        <!-- LOG_ID_FDS_SRV_CON -->
+    <rule id="100307" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022915$</field>
         <description>FortiGate Cloud server connected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100308" level="4">
-        <!-- LOG_ID_FDS_STATUS -->
+    <rule id="100308" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022916$</field>
         <description>FortiGuard Message Service status</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100309" level="4">
-        <!-- LOG_ID_FDS_SMS_QUOTA -->
+    <rule id="100309" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022917$</field>
         <description>SMS quota reached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100310" level="4">
-        <!-- LOG_ID_FDS_CTRL_STATUS -->
+    <rule id="100310" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022918$</field>
         <description>FortiGuard Message Service controller status</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100311" level="4">
-        <!-- LOG_ID_SVR_LOG_STATUS_CHANGED -->
+    <rule id="100311" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022919$</field>
         <description>Server logging status changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100312" level="4">
-        <!-- LOG_ID_EVENT_ROUTE_INFO_CHANGED -->
+    <rule id="100312" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022921$</field>
         <description>Routing information changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100313" level="4">
-        <!-- LOG_ID_EVENT_LINK_MONITOR_STATUS -->
+    <rule id="100313" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022922$</field>
         <description>Link monitor status</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100314" level="4">
-        <!-- LOG_ID_EVENT_VWL_LQTY_STATUS -->
+    <rule id="100314" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022923$</field>
         <description>SDWAN status</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100315" level="4">
-        <!-- LOG_ID_EVENT_VWL_VOLUME_STATUS -->
+    <rule id="100315" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022924$</field>
         <description>SDWAN volume status</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100316" level="4">
-        <!-- LOG_ID_EVENT_VWL_SLA_INFO -->
+    <rule id="100316" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022925$</field>
         <description>SDWAN SLA information</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.information</group>
     </rule>
 
-    <rule id="100317" level="4">
-        <!-- LOG_ID_EVENT_VWL_NEIGHBOR_STATUS -->
+    <rule id="100317" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022926$</field>
         <description>SDWAN Neighbor status</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100318" level="4">
-        <!-- LOG_ID_EVENT_VWL_NEIGHBOR_STANDALONE -->
+    <rule id="100318" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022927$</field>
         <description>SDWAN Neighbor standalone</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100319" level="4">
-        <!-- LOG_ID_EVENT_VWL_NEIGHBOR_PRIMARY -->
+    <rule id="100319" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022928$</field>
         <description>SDWAN Neighbor primary</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100320" level="4">
-        <!-- LOG_ID_EVENT_VWL_NEIGHBOR_SECONDARY -->
+    <rule id="100320" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022929$</field>
         <description>SDWAN Neighbor secondary</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100321" level="4">
-        <!-- LOG_ID_EVENT_VWL_LQTY_STATUS_WARNING -->
+    <rule id="100321" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022930$</field>
         <description>SDWAN status warning</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100322" level="4">
-        <!-- LOG_ID_EVENT_VWL_SLA_INFO_WARNING -->
+    <rule id="100322" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022931$</field>
         <description>SDWAN SLA information warning</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100323" level="4">
-        <!-- LOG_ID_EVENT_LINK_MONITOR_STATUS_WARNING -->
+    <rule id="100323" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022932$</field>
         <description>Link monitor status warning</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100324" level="4">
-        <!-- LOG_ID_EVENT_VWL_SLA_INFO_NOTIF -->
+    <rule id="100324" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022933$</field>
         <description>SDWAN SLA notification</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100325" level="4">
-        <!-- LOG_ID_EVENT_VWL_LQTY_STATUS_INFO -->
+    <rule id="100325" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022934$</field>
         <description>SDWAN status information</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.information</group>
     </rule>
 
-    <rule id="100326" level="4">
-        <!-- LOG_ID_EVENT_VWL_LQTY_STATUS_DEBUG -->
+    <rule id="100326" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022935$</field>
         <description>SDWAN status debug</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100327" level="4">
-        <!-- LOG_ID_EVENT_VWL_INET_SVC_PQTY_STATUS_INFO -->
+    <rule id="100327" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022936$</field>
         <description>Virtual WAN Link internet service passive quality information</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.information</group>
     </rule>
 
-    <rule id="100328" level="4">
-        <!-- LOG_ID_FDS_JOIN -->
+    <rule id="100328" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022949$</field>
         <description>FortiGate Cloud auto-join attempted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100329" level="4">
-        <!-- LOG_ID_FDS_LOGIN_SUCC -->
+    <rule id="100329" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022950$</field>
         <description>FortiGate Cloud activation successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100330" level="4">
-        <!-- LOG_ID_FDS_LOGOUT -->
+    <rule id="100330" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022951$</field>
         <description>FortiGate Cloud logout</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100331" level="4">
-        <!-- LOG_ID_FDS_LOGIN_FAIL -->
+    <rule id="100331" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022952$</field>
         <description>FortiGate Cloud activation failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100332" level="4">
-        <!-- LOG_ID_INET_SVC_OBSOLETE -->
+    <rule id="100332" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022954$</field>
         <description>Internet Service obsolete</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100333" level="4">
-        <!-- LOG_ID_INET_SVC_NAME_FAILURE -->
+    <rule id="100333" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022955$</field>
         <description>Internet Service name update failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100334" level="4">
-        <!-- LOG_ID_INET_SVC_NAME_UPDATE -->
+    <rule id="100334" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022956$</field>
         <description>Internet Service name update</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100335" level="4">
-        <!-- LOG_ID_IPSEC_TUNNEL_UP -->
+    <rule id="100335" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">023101$</field>
         <description>IPsec VPN tunnel up</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100336" level="4">
-        <!-- LOG_ID_IPSEC_TUNNEL_DOWN -->
+    <rule id="100336" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">023102$</field>
         <description>IPsec VPN tunnel down</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100337" level="4">
-        <!-- LOG_ID_IPSEC_TUNNEL_STAT -->
+    <rule id="100337" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">023103$</field>
         <description>IPsec VPN tunnel statistics</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100338" level="4">
-        <!-- LOG_ID_DHCP_ACK -->
+    <rule id="100338" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026001$</field>
         <description>DHCP Ack log</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100339" level="4">
-        <!-- LOG_ID_DHCP_RELEASE -->
+    <rule id="100339" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026002$</field>
         <description>DHCP Release log</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100340" level="4">
-        <!-- LOG_ID_DHCP_STAT -->
+    <rule id="100340" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026003$</field>
         <description>DHCP statistics</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100341" level="4">
-        <!-- LOG_ID_DHCP_CLIENT_LEASE -->
+    <rule id="100341" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026004$</field>
         <description>DHCP client lease granted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100342" level="4">
-        <!-- LOG_ID_DHCP_LEASE_USAGE_HIGH -->
+    <rule id="100342" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026005$</field>
         <description>DHCP lease usage high</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100343" level="4">
-        <!-- LOG_ID_DHCP_LEASE_USAGE_FULL -->
+    <rule id="100343" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026006$</field>
         <description>DHCP lease usage full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100344" level="4">
-        <!-- LOG_ID_DHCP_BLOCKED_MAC -->
+    <rule id="100344" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026007$</field>
         <description>DHCP client blocked log</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100345" level="4">
-        <!-- LOG_ID_DHCP_DDNS_ADD -->
+    <rule id="100345" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026008$</field>
         <description>DHCP DDNS add query</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100346" level="4">
-        <!-- LOG_ID_DHCP_DDNS_DELETE -->
+    <rule id="100346" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026009$</field>
         <description>DHCP DDNS delete query</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100347" level="4">
-        <!-- LOG_ID_DHCP_DDNS_COMPLETED -->
+    <rule id="100347" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026010$</field>
         <description>DHCP DDNS query completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100348" level="4">
-        <!-- LOG_ID_DHCPV6_REPLY -->
+    <rule id="100348" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026011$</field>
         <description>DHCPv6 Ack log</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100349" level="4">
-        <!-- LOG_ID_DHCPV6_RELEASE -->
+    <rule id="100349" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">026012$</field>
         <description>DHCPv6 Release log</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100350" level="4">
-        <!-- LOG_ID_VRRP_STATE_CHG -->
+    <rule id="100350" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">027001$</field>
         <description>VRRP state changed</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.information</group>
     </rule>
 
-    <rule id="100351" level="4">
-        <!-- LOG_ID_PPPD_MSG -->
+    <rule id="100351" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029001$</field>
         <description>PPP status</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100352" level="4">
-        <!-- LOG_ID_PPPD_AUTH_SUC -->
+    <rule id="100352" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029002$</field>
         <description>PPP authentication successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100353" level="4">
-        <!-- LOG_ID_PPPD_AUTH_FAIL -->
+    <rule id="100353" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029003$</field>
         <description>PPP authentication failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100354" level="4">
-        <!-- LOG_ID_PPPD_MSG_ERROR -->
+    <rule id="100354" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029004$</field>
         <description>PPP status error message</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100355" level="4">
-        <!-- LOG_ID_PPPD_MSG_DEBUG -->
+    <rule id="100355" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029005$</field>
         <description>PPP status debug message</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100356" level="4">
-        <!-- LOG_ID_PPPOE_STATUS_REPORT_NOTIF -->
+    <rule id="100356" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029010$</field>
         <description>PPPoE status report</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100357" level="4">
-        <!-- LOG_ID_PPPD_FAIL_TO_EXEC -->
+    <rule id="100357" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029011$</field>
         <description>PPP execution failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100358" level="4">
-        <!-- LOG_ID_PPPD_START -->
+    <rule id="100358" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029013$</field>
         <description>PPP daemon started</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100359" level="4">
-        <!-- LOG_ID_PPPD_EXIT -->
+    <rule id="100359" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029014$</field>
         <description>PPP daemon exited</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100360" level="4">
-        <!-- LOG_ID_PPP_RCV_BAD_PEER_IP -->
+    <rule id="100360" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029015$</field>
         <description>PPP received invalid peer IP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100361" level="4">
-        <!-- LOG_ID_PPP_RCV_BAD_LOCAL_IP -->
+    <rule id="100361" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029016$</field>
         <description>PPP received invalid local IP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100362" level="4">
-        <!-- LOG_ID_EVENT_AUTH_SNMP_QUERY_FAILED -->
+    <rule id="100362" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029021$</field>
         <description>SNMP query failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100363" level="4">
-        <!-- LOG_ID_DDNS_UPDATE_FAIL -->
+    <rule id="100363" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">029022$</field>
         <description>DDNS update failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100364" level="4">
-        <!-- LOG_ID_ADMIN_LOGIN_SUCC -->
+    <rule id="100364" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032001$</field>
         <description>Admin login successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100365" level="4">
-        <!-- LOG_ID_ADMIN_LOGIN_FAIL -->
+    <rule id="100365" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032002$</field>
         <description>Admin login failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100366" level="4">
-        <!-- LOG_ID_ADMIN_LOGOUT -->
+    <rule id="100366" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032003$</field>
         <description>Admin logout successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100367" level="4">
-        <!-- LOG_ID_ADMIN_OVERIDE_VDOM -->
+    <rule id="100367" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032005$</field>
         <description>Admin overrode VDOM</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100368" level="4">
-        <!-- LOG_ID_ADMIN_ENTER_VDOM -->
+    <rule id="100368" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032006$</field>
         <description>Super admin entered VDOM</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100369" level="4">
-        <!-- LOG_ID_ADMIN_LEFT_VDOM -->
+    <rule id="100369" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032007$</field>
         <description>Super admin left VDOM</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100370" level="4">
-        <!-- LOG_ID_VIEW_DISK_LOG_FAIL -->
+    <rule id="100370" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032008$</field>
         <description>Disk log access failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100371" level="4">
-        <!-- LOG_ID_SYSTEM_START -->
+    <rule id="100371" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032009$</field>
         <description>FortiGate started</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100372" level="4">
-        <!-- LOG_ID_DISK_LOG_FULL -->
+    <rule id="100372" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032010$</field>
         <description>Disk full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100373" level="4">
-        <!-- LOG_ID_LOG_ROLL -->
+    <rule id="100373" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032011$</field>
         <description>Disk log rolled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100374" level="4">
-        <!-- LOG_ID_CS_LIC_EXPIRE -->
+    <rule id="100374" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032014$</field>
         <description>Support license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100375" level="4">
-        <!-- LOG_ID_DISK_LOG_USAGE -->
+    <rule id="100375" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032015$</field>
         <description>Log disk full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100376" level="4">
-        <!-- LOG_ID_FDS_DAILY_QUOTA_FULL -->
+    <rule id="100376" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032017$</field>
         <description>FortiGate Cloud daily quota full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100377" level="4">
-        <!-- LOG_ID_FIPS_ENTER_ERR_MOD -->
+    <rule id="100377" level="15">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032018$</field>
         <description>FIPS CC entered error mode</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100378" level="4">
-        <!-- LOG_ID_CC_ENTER_ERR_MOD -->
+    <rule id="100378" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032019$</field>
         <description>CC entered error mode</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100379" level="4">
-        <!-- LOG_ID_SSH_CORRPUT_MAC -->
+    <rule id="100379" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032020$</field>
         <description>Message Authentication Code corrupted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100380" level="4">
-        <!-- LOG_ID_ADMIN_LOGIN_DISABLE -->
+    <rule id="100380" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032021$</field>
         <description>Admin login disabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100381" level="4">
-        <!-- LOG_ID_VDOM_ENABLED -->
+    <rule id="100381" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032022$</field>
         <description>VDOM enabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100382" level="4">
-        <!-- LOG_ID_MEM_LOG_FIRST_FULL -->
+    <rule id="100382" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032023$</field>
         <description>Memory log full over first warning level</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100383" level="4">
-        <!-- LOG_ID_ADMIN_PASSWD_EXPIRE -->
+    <rule id="100383" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032024$</field>
         <description>Admin password expired</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100384" level="4">
-        <!-- LOG_ID_SSH_REKEY -->
+    <rule id="100384" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032025$</field>
         <description>SSH server re-key</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100385" level="4">
-        <!-- LOG_ID_SSH_BAD_PACKET_LENGTH -->
+    <rule id="100385" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032026$</field>
         <description>SSH server received bad length packet</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100386" level="4">
-        <!-- LOG_ID_VIEW_DISK_LOG_SUCC -->
+    <rule id="100386" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032027$</field>
         <description>Disk logs viewed successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100387" level="4">
-        <!-- LOG_ID_LOG_DEL_DIR -->
+    <rule id="100387" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032028$</field>
         <description>Disk log directory deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100388" level="4">
-        <!-- LOG_ID_LOG_DEL_FILE -->
+    <rule id="100388" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032029$</field>
         <description>Disk log file deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100389" level="4">
-        <!-- LOG_ID_SEND_FDS_STAT -->
+    <rule id="100389" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032030$</field>
         <description>FDS statistics sent</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100390" level="4">
-        <!-- LOG_ID_VIEW_MEM_LOG_FAIL -->
+    <rule id="100390" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032031$</field>
         <description>Memory log access failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100391" level="4">
-        <!-- LOG_ID_DISK_DLP_ARCH_FULL -->
+    <rule id="100391" level="15">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032032$</field>
         <description>DLP archive full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100392" level="4">
-        <!-- LOG_ID_DISK_QUAR_FULL -->
+    <rule id="100392" level="15">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032033$</field>
         <description>Quarantine full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100393" level="4">
-        <!-- LOG_ID_DISK_REPORT_FULL -->
+    <rule id="100393" level="15">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032034$</field>
         <description>Report db data full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100394" level="4">
-        <!-- LOG_ID_VDOM_DISABLED -->
+    <rule id="100394" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032035$</field>
         <description>VDOM disabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100395" level="4">
-        <!-- LOG_ID_DISK_IPS_ARCH_FULL -->
+    <rule id="100395" level="15">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032036$</field>
         <description>IPS archive full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100396" level="4">
-        <!-- LOG_ID_DISK_LOG_FIRST_FULL -->
+    <rule id="100396" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032037$</field>
         <description>Disk log full over first warning</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100397" level="4">
-        <!-- LOG_ID_LOG_ROLL_FORTICRON -->
+    <rule id="100397" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032038$</field>
         <description>Log rotation requested by FortiCron</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100398" level="4">
-        <!-- LOG_ID_VIEW_MEM_LOG_SUCC -->
+    <rule id="100398" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032039$</field>
         <description>Memory logs viewed successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100399" level="4">
-        <!-- LOG_ID_REPORT_DELETED -->
+    <rule id="100399" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032040$</field>
         <description>Report deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100400" level="4">
-        <!-- LOG_ID_REPORT_DELETED_GUI -->
+    <rule id="100400" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032041$</field>
         <description>Report deleted from GUI</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100401" level="4">
-        <!-- LOG_ID_MEM_LOG_SECOND_FULL -->
+    <rule id="100401" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032042$</field>
         <description>Memory log full over second warning level</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100402" level="4">
-        <!-- LOG_ID_MEM_LOG_FINAL_FULL -->
+    <rule id="100402" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032043$</field>
         <description>Memory log full over final warning level</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100403" level="4">
-        <!-- LOG_ID_LOG_DELETE -->
+    <rule id="100403" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032044$</field>
         <description>Log deleted by user</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100404" level="4">
-        <!-- LOG_ID_MGR_LIC_EXPIRE -->
+    <rule id="100404" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032045$</field>
         <description>FortiGuard management service license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100405" level="4">
-        <!-- LOG_ID_SCHEDULE_EXPIRE -->
+    <rule id="100405" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032048$</field>
         <description>One time schedule expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100406" level="4">
-        <!-- LOG_ID_FC_EXPIRE -->
+    <rule id="100406" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032049$</field>
         <description>FortiGate Cloud license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100407" level="4">
-        <!-- LOG_ID_POL_PKT_CAPTURE_FULL -->
+    <rule id="100407" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032050$</field>
         <description>Policy packet capture full</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100408" level="4">
-        <!-- LOG_ID_LOG_UPLOAD -->
+    <rule id="100408" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032051$</field>
         <description>Disk logs upload started</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100409" level="4">
-        <!-- LOG_ID_UPLOAD_RUN_SCRIPT -->
+    <rule id="100409" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032052$</field>
         <description>Upload and run a script</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100410" level="4">
-        <!-- LOG_ID_VIEW_FAZ_LOG_FAIL -->
+    <rule id="100410" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032057$</field>
         <description>FortiAnalyzer log access failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100411" level="4">
-        <!-- LOG_ID_VIEW_FAZ_LOG_SUCC -->
+    <rule id="100411" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032058$</field>
         <description>FortiAnalyzer logs viewed successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100412" level="4">
-        <!-- LOG_ID_GUI_CHG_SUB_MODULE -->
+    <rule id="100412" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032095$</field>
         <description>Admin performed an action from GUI</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100413" level="4">
-        <!-- LOG_ID_GUI_DOWNLOAD_LOG -->
+    <rule id="100413" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032096$</field>
         <description>Log file downloaded from GUI</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100414" level="4">
-        <!-- LOG_ID_DELETE_CAPTURE_PKT -->
+    <rule id="100414" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032097$</field>
         <description>Policy packet capture file deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100415" level="4">
-        <!-- LOG_ID_CHG_CONFIG_INFO -->
+    <rule id="100415" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032099$</field>
         <description>Configuration changed information</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100416" level="4">
-        <!-- LOG_ID_FORTI_TOKEN_SYNC -->
+    <rule id="100416" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032100$</field>
         <description>FortiToken synchronized</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100417" level="4">
-        <!-- LOG_ID_CHG_CONFIG -->
+    <rule id="100417" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032102$</field>
         <description>Configuration changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100418" level="4">
-        <!-- LOG_ID_NEW_FIRMWARE -->
+    <rule id="100418" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032103$</field>
         <description>New firmware available on FortiGuard</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100419" level="4">
-        <!-- LOG_ID_CHG_CONFIG_GUI -->
+    <rule id="100419" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032104$</field>
         <description>Configuration changed via GUI</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100420" level="4">
-        <!-- LOG_ID_NTP_SVR_STAUS_CHG_REACHABLE -->
+    <rule id="100420" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032105$</field>
         <description>NTP server status changes to reachable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100421" level="4">
-        <!-- LOG_ID_NTP_SVR_STAUS_CHG_RESOLVABLE -->
+    <rule id="100421" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032106$</field>
         <description>NTP server status changes to resolvable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100422" level="4">
-        <!-- LOG_ID_NTP_SVR_STAUS_CHG_UNRESOLVABLE -->
+    <rule id="100422" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032107$</field>
         <description>NTP server status changes to unresolvable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100423" level="4">
-        <!-- LOG_ID_NTP_SVR_STAUS_CHG_UNREACHABLE -->
+    <rule id="100423" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032108$</field>
         <description>NTP server status changes to unreachable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100424" level="4">
-        <!-- LOG_ID_UPD_SIGN_AV_DB -->
+    <rule id="100424" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032109$</field>
         <description>Updating virus database</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100425" level="4">
-        <!-- LOG_ID_UPD_SIGN_IPS_DB -->
+    <rule id="100425" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032110$</field>
         <description>IPS database updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100426" level="4">
-        <!-- LOG_ID_UPD_SIGN_AVIPS_DB -->
+    <rule id="100426" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032111$</field>
         <description>AV, IPS, GeoIP, SRC-VIS, FortiFlow, URL White-list, Certificate databases updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100427" level="4">
-        <!-- LOG_ID_UPD_SIGN_SRCVIS_DB -->
+    <rule id="100427" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032113$</field>
         <description>SRC-VIS object updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100428" level="4">
-        <!-- LOG_ID_UPD_SIGN_GEOIP_DB -->
+    <rule id="100428" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032114$</field>
         <description>GeoIP object updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100429" level="4">
-        <!-- LOG_ID_UPD_SIGN_AVPKG_FAILURE -->
+    <rule id="100429" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032116$</field>
         <description>AV package update by SCP failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100430" level="4">
-        <!-- LOG_ID_UPD_SIGN_AVPKG_SUCCESS -->
+    <rule id="100430" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032117$</field>
         <description>AV package update by SCP successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100431" level="4">
-        <!-- LOG_ID_UPD_ADMIN_AV_DB -->
+    <rule id="100431" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032118$</field>
         <description>AV updated by admin</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100432" level="4">
-        <!-- LOG_ID_UPD_SCANUNIT_AV_DB -->
+    <rule id="100432" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032119$</field>
         <description>AV database updated by scanunit</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100433" level="4">
-        <!-- LOG_ID_ADD_GUEST -->
+    <rule id="100433" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032129$</field>
         <description>Guest user added</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100434" level="4">
-        <!-- LOG_ID_CHG_USER -->
+    <rule id="100434" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032130$</field>
         <description>User changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100435" level="4">
-        <!-- LOG_ID_DEL_GUEST -->
+    <rule id="100435" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032131$</field>
         <description>Guest user deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100436" level="4">
-        <!-- LOG_ID_ADD_USER -->
+    <rule id="100436" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032132$</field>
         <description>Local user added</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100437" level="4">
-        <!-- LOG_ID_REBOOT -->
+    <rule id="100437" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032138$</field>
         <description>Device rebooted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100438" level="4">
-        <!-- LOG_ID_WAKE_ON_LAN -->
+    <rule id="100438" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032139$</field>
         <description>Wake on LAN device</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100439" level="4">
-        <!-- LOG_ID_TIME_USER_SETTING_CHG -->
+    <rule id="100439" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032140$</field>
         <description>Global time setting changed by user</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100440" level="4">
-        <!-- LOG_ID_TIME_NTP_SETTING_CHG -->
+    <rule id="100440" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032141$</field>
         <description>Global time setting changed by NTP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100441" level="4">
-        <!-- LOG_ID_BACKUP_CONF -->
+    <rule id="100441" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032142$</field>
         <description>System configuration backed up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100442" level="4">
-        <!-- LOG_ID_BACKUP_CONF_BY_SCP -->
+    <rule id="100442" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032143$</field>
         <description>System configuration backed up by SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100443" level="4">
-        <!-- LOG_ID_BACKUP_CONF_ERROR -->
+    <rule id="100443" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032144$</field>
         <description>System configuration backed up error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100444" level="4">
-        <!-- LOG_ID_BACKUP_CONF_ALERT -->
+    <rule id="100444" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032145$</field>
         <description>System configuration backed up alert</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100445" level="4">
-        <!-- LOG_ID_TIME_PTP_SETTING_CHG -->
+    <rule id="100445" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032146$</field>
         <description>Global time setting changed by PTP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100446" level="4">
-        <!-- LOG_ID_GET_CRL -->
+    <rule id="100446" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032148$</field>
         <description>CRL update requested</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100447" level="4">
-        <!-- LOG_ID_COMMAND_FAIL -->
+    <rule id="100447" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032149$</field>
         <description>Command failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100448" level="4">
-        <!-- LOG_ID_ADD_IP6_LOCAL_POL -->
+    <rule id="100448" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032151$</field>
         <description>IPv6 firewall local in policy added</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100449" level="4">
-        <!-- LOG_ID_CHG_IP6_LOCAL_POL -->
+    <rule id="100449" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032152$</field>
         <description>IPv6 firewall local in policy setting changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100450" level="4">
-        <!-- LOG_ID_DEL_IP6_LOCAL_POL -->
+    <rule id="100450" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032153$</field>
         <description>IPv6 firewall local in policy deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100451" level="4">
-        <!-- LOG_ID_ACT_FTOKEN_REQ -->
+    <rule id="100451" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032155$</field>
         <description>FortiToken activation requested</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100452" level="4">
-        <!-- LOG_ID_ACT_FTOKEN_SUCC -->
+    <rule id="100452" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032156$</field>
         <description>FortiToken activation successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100453" level="4">
-        <!-- LOG_ID_SYNC_FTOKEN_SUCC -->
+    <rule id="100453" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032157$</field>
         <description>FortiToken re-synchronized</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100454" level="4">
-        <!-- LOG_ID_SYNC_FTOKEN_FAIL -->
+    <rule id="100454" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032158$</field>
         <description>FortiToken re-synchronization failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100455" level="4">
-        <!-- LOG_ID_ACT_FTOKEN_FAIL -->
+    <rule id="100455" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032159$</field>
         <description>FortiToken activation failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100456" level="4">
-        <!-- LOG_ID_FTM_PUSH_SUCC -->
+    <rule id="100456" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032160$</field>
         <description>FortiToken mobile push message succeeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100457" level="4">
-        <!-- LOG_ID_FTM_PUSH_FAIL -->
+    <rule id="100457" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032161$</field>
         <description>FortiToken mobile push message failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100458" level="4">
-        <!-- LOG_ID_REACH_VDOM_LIMIT -->
+    <rule id="100458" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032168$</field>
         <description>VDOM limit reached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100459" level="4">
-        <!-- LOG_ID_ALARM_DLP_DB -->
+    <rule id="100459" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032169$</field>
         <description>DLP database space alarm</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100460" level="4">
-        <!-- LOG_ID_ALARM_MSG -->
+    <rule id="100460" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032170$</field>
         <description>Alarm created</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100461" level="4">
-        <!-- LOG_ID_ALARM_ACK -->
+    <rule id="100461" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032171$</field>
         <description>Alarm acknowledged</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100462" level="4">
-        <!-- LOG_ID_ADD_IP4_LOCAL_POL -->
+    <rule id="100462" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032172$</field>
         <description>IPv4 firewall local in policy added</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100463" level="4">
-        <!-- LOG_ID_CHG_IP4_LOCAL_POL -->
+    <rule id="100463" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032173$</field>
         <description>IPv4 firewall local in policy's setting changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100464" level="4">
-        <!-- LOG_ID_DEL_IP4_LOCAL_POL -->
+    <rule id="100464" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032174$</field>
         <description>IPv4 firewall local in policy deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100465" level="4">
-        <!-- LOG_ID_GEOIP_DB_INIT_FAIL -->
+    <rule id="100465" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032180$</field>
         <description>IP Geography DB initialization failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100466" level="4">
-        <!-- LOG_ID_UPT_INVALID_IMG -->
+    <rule id="100466" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032190$</field>
         <description>Invalid image loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100467" level="4">
-        <!-- LOG_ID_UPT_INVALID_IMG_CC -->
+    <rule id="100467" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032191$</field>
         <description>Image with invalid CC signature loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100468" level="4">
-        <!-- LOG_ID_UPT_INVALID_IMG_RSA -->
+    <rule id="100468" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032192$</field>
         <description>Image with invalid RSA signature loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100469" level="4">
-        <!-- LOG_ID_UPT_IMG_RSA -->
+    <rule id="100469" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032193$</field>
         <description>Image with valid RSA signature loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100470" level="4">
-        <!-- LOG_ID_UPT_IMG_FAIL -->
+    <rule id="100470" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032194$</field>
         <description>System upgrade failed due to file operation failure</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100471" level="4">
-        <!-- LOG_ID_SHUTDOWN -->
+    <rule id="100471" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032200$</field>
         <description>Device shutdown</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100472" level="4">
-        <!-- LOG_ID_LOAD_IMG_SUCC -->
+    <rule id="100472" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032201$</field>
         <description>Image loaded successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100473" level="4">
-        <!-- LOG_ID_RESTORE_IMG -->
+    <rule id="100473" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032202$</field>
         <description>Image restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100474" level="4">
-        <!-- LOG_ID_RESTORE_CONF -->
+    <rule id="100474" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032203$</field>
         <description>Configuration restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100475" level="4">
-        <!-- LOG_ID_RESTORE_FGD_SVR -->
+    <rule id="100475" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032204$</field>
         <description>FortiGuard service restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100476" level="4">
-        <!-- LOG_ID_RESTORE_VDOM_LIC -->
+    <rule id="100476" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032205$</field>
         <description>VM license restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100477" level="4">
-        <!-- LOG_ID_RESTORE_SCRIPT -->
+    <rule id="100477" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032206$</field>
         <description>Script restored from management station</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100478" level="4">
-        <!-- LOG_ID_RETRIEVE_CONF_LIST -->
+    <rule id="100478" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032207$</field>
         <description>Configuration list retrieval failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100479" level="4">
-        <!-- LOG_ID_IMP_PKCS12_CERT -->
+    <rule id="100479" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032208$</field>
         <description>PKCS12 certificate imported</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100480" level="4">
-        <!-- LOG_ID_RESTORE_USR_DEF_IPS -->
+    <rule id="100480" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032209$</field>
         <description>IPS custom signatures restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100481" level="4">
-        <!-- LOG_ID_BACKUP_IMG_SUCC -->
+    <rule id="100481" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032210$</field>
         <description>Firmware image backed up successfully</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100482" level="4">
-        <!-- LOG_ID_UPLOAD_REVISION -->
+    <rule id="100482" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032211$</field>
         <description>Revision uploaded to flash disk</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100483" level="4">
-        <!-- LOG_ID_DEL_REVISION -->
+    <rule id="100483" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032212$</field>
         <description>Revision deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100484" level="4">
-        <!-- LOG_ID_RESTORE_TEMPLATE -->
+    <rule id="100484" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032213$</field>
         <description>Template restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100485" level="4">
-        <!-- LOG_ID_RESTORE_FILE -->
+    <rule id="100485" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032214$</field>
         <description>File restore failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100486" level="4">
-        <!-- LOG_ID_UPT_IMG -->
+    <rule id="100486" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032215$</field>
         <description>Image updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100487" level="4">
-        <!-- LOG_ID_UPD_IPS -->
+    <rule id="100487" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032217$</field>
         <description>IPS package - Admin update successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100488" level="4">
-        <!-- LOG_ID_UPD_DLP -->
+    <rule id="100488" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032218$</field>
         <description>DLP fingerprint database update via SCP failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100489" level="4">
-        <!-- LOG_ID_BACKUP_OUTPUT -->
+    <rule id="100489" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032219$</field>
         <description>Error output backup via SCP successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100490" level="4">
-        <!-- LOG_ID_BACKUP_COMMAND -->
+    <rule id="100490" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032220$</field>
         <description>Batch mode command output backup via SCP successful</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100491" level="4">
-        <!-- LOG_ID_UPD_VDOM_LIC -->
+    <rule id="100491" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032221$</field>
         <description>VM license installed via SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100492" level="4">
-        <!-- LOG_ID_GLB_SETTING_CHG -->
+    <rule id="100492" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032222$</field>
         <description>Global setting changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100493" level="4">
-        <!-- LOG_ID_BACKUP_USER_DEF_IPS -->
+    <rule id="100493" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032223$</field>
         <description>IPS custom signatures backup success</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100494" level="4">
-        <!-- LOG_ID_BACKUP_DISK_LOG -->
+    <rule id="100494" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032224$</field>
         <description>Disk logs backed up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100495" level="4">
-        <!-- LOG_ID_DEL_ALL_REVISION -->
+    <rule id="100495" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032225$</field>
         <description>Revision database reset due to data corruption</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100496" level="4">
-        <!-- LOG_ID_LOAD_IMG_FAIL -->
+    <rule id="100496" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032226$</field>
         <description>Image failed to load</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100497" level="4">
-        <!-- LOG_ID_UPD_DLP_FAIL -->
+    <rule id="100497" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032227$</field>
         <description>DLP fingerprint database failed to update by SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100498" level="4">
-        <!-- LOG_ID_LOAD_IMG_FAIL_WRONG_IMG -->
+    <rule id="100498" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032228$</field>
         <description>Firmware image loaded incorrect</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100499" level="4">
-        <!-- LOG_ID_LOAD_IMG_FAIL_NO_RSA -->
+    <rule id="100499" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032229$</field>
         <description>Firmware image without valid RSA signature loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100500" level="4">
-        <!-- LOG_ID_LOAD_IMG_FAIL_INVALID_RSA -->
+    <rule id="100500" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032230$</field>
         <description>Firmware image with invalid RSA signature loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100501" level="4">
-        <!-- LOG_ID_RESTORE_FGD_SVR_FAIL -->
+    <rule id="100501" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032231$</field>
         <description>FortiGuard service failed to restore</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100502" level="4">
-        <!-- LOG_ID_RESTORE_VDOM_LIC_FAIL -->
+    <rule id="100502" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032232$</field>
         <description>VM license failed to restore</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100503" level="4">
-        <!-- LOG_ID_BACKUP_IMG_FAIL -->
+    <rule id="100503" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032233$</field>
         <description>Firmware image backup failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100504" level="4">
-        <!-- LOG_ID_RESTORE_IMG_INVALID_CC -->
+    <rule id="100504" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032234$</field>
         <description>Image with invalid CC signature restored</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100505" level="4">
-        <!-- LOG_ID_RESTORE_IMG_FORTIGUARD -->
+    <rule id="100505" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032235$</field>
         <description>Image restored from FortiGuard Management</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100506" level="4">
-        <!-- LOG_ID_BACKUP_MEM_LOG -->
+    <rule id="100506" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032236$</field>
         <description>Memory logs backed up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100507" level="4">
-        <!-- LOG_ID_BACKUP_MEM_LOG_FAIL -->
+    <rule id="100507" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032237$</field>
         <description>Memory logs failed to back up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100508" level="4">
-        <!-- LOG_ID_BACKUP_DISK_LOG_FAIL -->
+    <rule id="100508" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032238$</field>
         <description>Disk logs failed to back up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100509" level="4">
-        <!-- LOG_ID_BACKUP_DISK_LOG_USB -->
+    <rule id="100509" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032239$</field>
         <description>Disk logs backed up to USB</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100510" level="4">
-        <!-- LOG_ID_SYS_USB_MODE -->
+    <rule id="100510" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032240$</field>
         <description>System operating in USB mode</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100511" level="4">
-        <!-- LOG_ID_BACKUP_DISK_LOG_USB_FAIL -->
+    <rule id="100511" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032241$</field>
         <description>Disk logs failed to back up to USB</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100512" level="4">
-        <!-- LOG_ID_UPD_VDOM_LIC_FAIL -->
+    <rule id="100512" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032242$</field>
         <description>VM license failed to install via SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100513" level="4">
-        <!-- LOG_ID_UPD_IPS_SCP -->
+    <rule id="100513" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032243$</field>
         <description>IPS package updated via SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100514" level="4">
-        <!-- LOG_ID_UPD_IPS_SCP_FAIL -->
+    <rule id="100514" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032244$</field>
         <description>IPS package failed to update via SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100515" level="4">
-        <!-- LOG_ID_BACKUP_USER_DEF_IPS_FAIL -->
+    <rule id="100515" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032245$</field>
         <description>IPS custom signatures backup failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100516" level="4">
-        <!-- LOG_ID_RESTORE_USR_DEF_IPS_CRITICAL -->
+    <rule id="100516" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032246$</field>
         <description>IPS custom signatures restored critical</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100517" level="4">
-        <!-- LOG_ID_SSH_NEGOTIATION_FAILURE -->
+    <rule id="100517" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032247$</field>
         <description>SSH protocol cannot be negotiated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100518" level="4">
-        <!-- LOG_ID_FACTORY_RESET -->
+    <rule id="100518" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032252$</field>
         <description>Factory settings reset</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100519" level="4">
-        <!-- LOG_ID_FORMAT_RAID -->
+    <rule id="100519" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032253$</field>
         <description>RAID disk formatted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100520" level="4">
-        <!-- LOG_ID_ENABLE_RAID -->
+    <rule id="100520" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032254$</field>
         <description>RAID enabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100521" level="4">
-        <!-- LOG_ID_DISABLE_RAID -->
+    <rule id="100521" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032255$</field>
         <description>RAID disabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100522" level="4">
-        <!-- LOG_ID_RESTORE_IMG_FORTIGUARD_NOTIF -->
+    <rule id="100522" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032260$</field>
         <description>Image restored from FortiGuard Management notification</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100523" level="4">
-        <!-- LOG_ID_RESTORE_SCRIPT_NOTIF -->
+    <rule id="100523" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032261$</field>
         <description>Script restored by user</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100524" level="4">
-        <!-- LOG_ID_RESTORE_IMG_CONFIRM -->
+    <rule id="100524" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032262$</field>
         <description>Image restore confirmed by user</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100525" level="4">
-        <!-- LOG_ID_BLE_FIRMWARE_CHECK -->
+    <rule id="100525" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032263$</field>
         <description>Bluetooth firmware check</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100526" level="4">
-        <!-- LOG_ID_BLE_FIRMWARE_UPDATE -->
+    <rule id="100526" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032264$</field>
         <description>Bluetooth firmware update</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100527" level="4">
-        <!-- LOG_ID_BLE_FIRMWARE_UPDATE -->
+    <rule id="100527" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032265$</field>
         <description>Bluetooth firmware update</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100528" level="4">
-        <!-- LOG_ID_SSH_HOST_KEY_REGEN -->
+    <rule id="100528" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032270$</field>
         <description>SSH host keys regenerated.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100529" level="4">
-        <!-- LOG_ID_UPLOAD_RPT_IMG -->
+    <rule id="100529" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032300$</field>
         <description>Report image file uploaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100530" level="4">
-        <!-- LOG_ID_ADD_VDOM -->
+    <rule id="100530" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032301$</field>
         <description>VDOM added</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100531" level="4">
-        <!-- LOG_ID_DEL_VDOM -->
+    <rule id="100531" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032302$</field>
         <description>VDOM deleted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100532" level="4">
-        <!-- LOG_ID_SYS_RESTART -->
+    <rule id="100532" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032545$</field>
         <description>Scheduled daily reboot started</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100533" level="4">
-        <!-- LOG_ID_APPLICATION_CRASH -->
+    <rule id="100533" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032546$</field>
         <description>Application crashed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100534" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_START -->
+    <rule id="100534" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032547$</field>
         <description>Autoscript start</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100535" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_STOP -->
+    <rule id="100535" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032548$</field>
         <description>Autoscript stop</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100536" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_STOP_AUTO -->
+    <rule id="100536" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032549$</field>
         <description>Autoscript stop automatically</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100537" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_DELETE_RSLT -->
+    <rule id="100537" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032550$</field>
         <description>Autoscript delete result</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100538" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_BACKUP_RSLT -->
+    <rule id="100538" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032551$</field>
         <description>Autoscript backup result</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100539" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_CHECK_STATUS -->
+    <rule id="100539" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032552$</field>
         <description>Autoscript check status</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100540" level="4">
-        <!-- LOG_ID_AUTOSCRIPT_STOP_REACH_LIMIT -->
+    <rule id="100540" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032553$</field>
         <description>Autoscript stop due to limit reached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100541" level="4">
-        <!-- LOG_ID_UPD_ADMIN_DB -->
+    <rule id="100541" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032554$</field>
         <description>Database updated by admin</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100542" level="4">
-        <!-- LOG_ID_ADMIN_LOGOUT_DISCONNECT -->
+    <rule id="100542" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032561$</field>
         <description>Admin disconnected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100543" level="4">
-        <!-- LOG_ID_STORE_CONF_FAIL_SPACE -->
+    <rule id="100543" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032562$</field>
         <description>Store config failed - not enough flash space</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100544" level="4">
-        <!-- LOG_ID_RESTORE_CONF_FAIL -->
+    <rule id="100544" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032564$</field>
         <description>Configuration failed to restore</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100545" level="4">
-        <!-- LOG_ID_RESTORE_CONF_BY_MGMT -->
+    <rule id="100545" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032565$</field>
         <description>Configuration restored from management station</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100546" level="4">
-        <!-- LOG_ID_RESTORE_CONF_BY_SCP -->
+    <rule id="100546" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032566$</field>
         <description>Configuration restored by SCP</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100547" level="4">
-        <!-- LOG_ID_DEL_REVISION_DB -->
+    <rule id="100547" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032568$</field>
         <description>Revision Database deletion</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100548" level="4">
-        <!-- LOG_ID_FSW_SWITCH_LOG_EVENT -->
+    <rule id="100548" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032569$</field>
         <description>Switch-Controller</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100549" level="4">
-        <!-- LOG_ID_RESTORE_CONF_FAIL_WARNING -->
+    <rule id="100549" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032571$</field>
         <description>Configuration failed to restore warning</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100550" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_DISCOVER -->
+    <rule id="100550" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032601$</field>
         <description>Switch-Controller discovered</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100551" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_AUTH -->
+    <rule id="100551" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032602$</field>
         <description>Switch-Controller authorized</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100552" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_DEAUTH -->
+    <rule id="100552" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032603$</field>
         <description>Switch-Controller deauthorized</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100553" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_DELETE -->
+    <rule id="100553" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032604$</field>
         <description>Switch-Controller deleted</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100554" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_TUNNEL_UP -->
+    <rule id="100554" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032605$</field>
         <description>Switch-Controller Tunnel Up</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100555" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_TUNNEL_DOWN -->
+    <rule id="100555" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032606$</field>
         <description>Switch-Controller Tunnel Down</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100556" level="4">
-        <!-- LOG_ID_FGT_SWITCH_PUSH_IMAGE -->
+    <rule id="100556" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032607$</field>
         <description>Image push to FortiSwitch</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100557" level="4">
-        <!-- LOG_ID_FGT_SWITCH_STAGE_IMAGE -->
+    <rule id="100557" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032608$</field>
         <description>Image stage to FortiSwitch</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100558" level="4">
-        <!-- LOG_ID_FGT_SWITCH_DISABLE_DISCOVERY -->
+    <rule id="100558" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032609$</field>
         <description>Disable FortiSwitch Discovery</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100559" level="4">
-        <!-- LOG_ID_FGT_SWITCH_LOG_WARNING -->
+    <rule id="100559" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032610$</field>
         <description>Switch-Controller warning</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100560" level="4">
-        <!-- LOG_ID_FGT_SWITCH_EXPORT_POOL -->
+    <rule id="100560" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032611$</field>
         <description>Export port to pool</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100561" level="4">
-        <!-- LOG_ID_FGT_SWITCH_EXPORT_VDOM -->
+    <rule id="100561" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032612$</field>
         <description>Export port to vdom</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100562" level="4">
-        <!-- LOG_ID_FGT_SWITCH_REQUEST_PORT -->
+    <rule id="100562" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032613$</field>
         <description>Request port from pool</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100563" level="4">
-        <!-- LOG_ID_FGT_SWITCH_RETURN_PORT -->
+    <rule id="100563" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032614$</field>
         <description>Return port to pool</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100564" level="4">
-        <!-- LOG_ID_FGT_SWITCH_MAC_ADD -->
+    <rule id="100564" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032615$</field>
         <description>FortiSwitch MAC add</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100565" level="4">
-        <!-- LOG_ID_FGT_SWITCH_MAC_DEL -->
+    <rule id="100565" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032616$</field>
         <description>FortiSwitch MAC delete</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100566" level="4">
-        <!-- LOG_ID_FGT_SWITCH_MAC_MOVE -->
+    <rule id="100566" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032617$</field>
         <description>FortiSwitch MAC move</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="100567" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_SWC -->
+    <rule id="100567" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032693$</field>
         <description>FortiSwitch switch controller</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100568" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_POE -->
+    <rule id="100568" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032694$</field>
         <description>FortiSwitch PoE</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100569" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_LINK -->
+    <rule id="100569" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032695$</field>
         <description>FortiSwitch link</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100570" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_STP -->
+    <rule id="100570" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032696$</field>
         <description>FortiSwitch spanning Tree</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100571" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_SWITCH -->
+    <rule id="100571" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032697$</field>
         <description>FortiSwitch switch</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100572" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_ROUTER -->
+    <rule id="100572" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032698$</field>
         <description>FortiSwitch router</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100573" level="4">
-        <!-- LOG_ID_FGT_SWITCH_GROUP_SYSTEM -->
+    <rule id="100573" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032699$</field>
         <description>FortiSwitch system</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100574" level="4">
-        <!-- LOG_ID_NP6_IPSEC_ENGINE_BUSY -->
+    <rule id="100574" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034415$</field>
         <description>NP6 IPsec engine is busy</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100575" level="4">
-        <!-- LOG_ID_NP6_IPSEC_ENGINE_POSSIBLY_LOCKUP -->
+    <rule id="100575" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034416$</field>
         <description>NP6 IPsec engine is possibly locked up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100576" level="4">
-        <!-- LOG_ID_NP6_IPSEC_ENGINE_LOCKUP -->
+    <rule id="100576" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034417$</field>
         <description>NP6 IPsec engine is locked up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100577" level="4">
-        <!-- LOG_ID_NP6_HPE_PACKET_DROP -->
+    <rule id="100577" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034418$</field>
         <description>NPU HPE is dropping packets</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100578" level="4">
-        <!-- LOG_ID_NP6_HPE_PACKET_FLOOD -->
+    <rule id="100578" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034419$</field>
         <description>NP6 HPE under a packets flood</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100579" level="4">
-        <!-- LOG_ID_NP7_HPE_PACKET_DROP -->
+    <rule id="100579" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034428$</field>
         <description>NPU HPE is dropping packets</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100580" level="4">
-        <!-- LOG_ID_NP7_HPE_PACKET_FLOOD -->
+    <rule id="100580" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034430$</field>
         <description>NPU HPE under packet flood</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100581" level="4">
-        <!-- LOG_ID_HA_SYNC_VIRDB -->
+    <rule id="100581" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035001$</field>
         <description>HA secondary synchronized Virus database</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100582" level="4">
-        <!-- LOG_ID_HA_SYNC_ETDB -->
+    <rule id="100582" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035002$</field>
         <description>HA secondary synchronized Extended database</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100583" level="4">
-        <!-- LOG_ID_HA_SYNC_EXDB -->
+    <rule id="100583" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035003$</field>
         <description>HA secondary synchronized Extreme database</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100584" level="4">
-        <!-- LOG_ID_HA_SYNC_FLDB -->
+    <rule id="100584" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035004$</field>
         <description>HA secondary synchronized FLDB</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100585" level="4">
-        <!-- LOG_ID_HA_SYNC_IPS -->
+    <rule id="100585" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035005$</field>
         <description>HA secondary synchronized IDS package</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100586" level="4">
-        <!-- LOG_ID_HA_SYNC_AV -->
+    <rule id="100586" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035007$</field>
         <description>HA secondary synchronized AntiVirus package</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100587" level="4">
-        <!-- LOG_ID_HA_SYNC_CID -->
+    <rule id="100587" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035009$</field>
         <description>HA secondary synchronized CID package</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100588" level="4">
-        <!-- LOG_ID_HA_SYNC_FAIL -->
+    <rule id="100588" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035011$</field>
         <description>HA secondary synchronization failed</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.error</group>
     </rule>
 
-    <rule id="100589" level="4">
-        <!-- LOG_ID_CONF_SYNC_FAIL -->
+    <rule id="100589" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035012$</field>
         <description>Secondary sync failed</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.error</group>
     </rule>
 
-    <rule id="100590" level="4">
-        <!-- LOG_ID_HA_FAILOVER_FAIL -->
+    <rule id="100590" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035013$</field>
         <description>HA failover failed</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.error</group>
     </rule>
 
-    <rule id="100591" level="4">
-        <!-- LOG_ID_HA_RESET_UPTIME -->
+    <rule id="100591" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035014$</field>
         <description>HA reset uptime</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.information</group>
     </rule>
 
-    <rule id="100592" level="4">
-        <!-- LOG_ID_HA_CLEAR_HISTORY -->
+    <rule id="100592" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035015$</field>
         <description>HA clear history</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.information</group>
     </rule>
 
-    <rule id="100593" level="4">
-        <!-- LOG_ID_HA_FAILOVER_SUCCESS -->
+    <rule id="100593" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035016$</field>
         <description>HA failover success</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100594" level="4">
-        <!-- LOG_ID_EVENT_SYSTEM_CFG_REVERT -->
+    <rule id="100594" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">036881$</field>
         <description>Configuration reverted due to timeout</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100595" level="4">
-        <!-- LOG_ID_EVENT_SYSTEM_CFG_MANUALLY_SAVED -->
+    <rule id="100595" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">036882$</field>
         <description>Configuration manually saved</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100596" level="4">
-        <!-- LOG_ID_EVENT_SYSTEM_CLEAR_ACTIVE_SESSION -->
+    <rule id="100596" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">036883$</field>
         <description>Clear active sessions</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100597" level="4">
-        <!-- MESGID_NEG_GENERIC_P1_NOTIF -->
+    <rule id="100597" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037120$</field>
         <description>Negotiate IPsec phase 1</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100598" level="4">
-        <!-- MESGID_NEG_GENERIC_P1_ERROR -->
+    <rule id="100598" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037121$</field>
         <description>Negotiate IPsec phase 1</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100599" level="4">
-        <!-- MESGID_NEG_GENERIC_P2_NOTIF -->
+    <rule id="100599" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037122$</field>
         <description>Negotiate IPsec phase 2</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100600" level="4">
-        <!-- MESGID_NEG_GENERIC_P2_ERROR -->
+    <rule id="100600" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037123$</field>
         <description>Negotiate IPsec phase 2</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100601" level="4">
-        <!-- MESGID_NEG_I_P1_ERROR -->
+    <rule id="100601" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037124$</field>
         <description>IPsec phase 1 error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100602" level="4">
-        <!-- MESGID_NEG_I_P2_ERROR -->
+    <rule id="100602" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037125$</field>
         <description>IPsec phase 2 error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100603" level="4">
-        <!-- MESGID_NEG_NO_STATE_ERROR -->
+    <rule id="100603" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037126$</field>
         <description>IPsec no state error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100604" level="4">
-        <!-- MESGID_NEG_PROGRESS_P1_NOTIF -->
+    <rule id="100604" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037127$</field>
         <description>Progress IPsec phase 1</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100605" level="4">
-        <!-- MESGID_NEG_PROGRESS_P1_ERROR -->
+    <rule id="100605" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037128$</field>
         <description>Progress IPsec phase 1</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100606" level="4">
-        <!-- MESGID_NEG_PROGRESS_P2_NOTIF -->
+    <rule id="100606" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037129$</field>
         <description>Progress IPsec phase 2</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100607" level="4">
-        <!-- MESGID_NEG_PROGRESS_P2_ERROR -->
+    <rule id="100607" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037130$</field>
         <description>Progress IPsec phase 2</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100608" level="4">
-        <!-- MESGID_ESP_ERROR -->
+    <rule id="100608" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037131$</field>
         <description>IPsec ESP</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100609" level="4">
-        <!-- MESGID_ESP_CRITICAL -->
+    <rule id="100609" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037132$</field>
         <description>IPsec ESP</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100610" level="4">
-        <!-- MESGID_INSTALL_SA -->
+    <rule id="100610" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037133$</field>
         <description>IPsec SA installed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100611" level="4">
-        <!-- MESGID_DELETE_P1_SA -->
+    <rule id="100611" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037134$</field>
         <description>IPsec phase 1 SA deleted</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100612" level="4">
-        <!-- MESGID_DELETE_P2_SA -->
+    <rule id="100612" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037135$</field>
         <description>IPsec phase 2 SA deleted</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100613" level="4">
-        <!-- MESGID_DPD_FAILURE -->
+    <rule id="100613" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037136$</field>
         <description>IPsec DPD failed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100614" level="4">
-        <!-- MESGID_CONN_FAILURE -->
+    <rule id="100614" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037137$</field>
         <description>IPsec connection failed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100615" level="4">
-        <!-- MESGID_CONN_UPDOWN -->
+    <rule id="100615" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037138$</field>
         <description>IPsec connection status changed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100616" level="4">
-        <!-- MESGID_P2_UPDOWN -->
+    <rule id="100616" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037139$</field>
         <description>IPsec phase 2 status changed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100617" level="4">
-        <!-- MESGID_CONN_STATS -->
+    <rule id="100617" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037141$</field>
         <description>IPsec tunnel statistics</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100618" level="4">
-        <!-- MESGID_VC_DELETE -->
+    <rule id="100618" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037889$</field>
         <description>Virtual cluster deleted</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100619" level="4">
-        <!-- MESGID_VC_MOVE_VDOM -->
+    <rule id="100619" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037890$</field>
         <description>Virtual cluster VDOM moved</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100620" level="4">
-        <!-- MESGID_VC_ADD_VDOM -->
+    <rule id="100620" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037891$</field>
         <description>Virtual cluster VDOM added</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100621" level="4">
-        <!-- MESGID_VC_MOVE_MEMB_STATE -->
+    <rule id="100621" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037892$</field>
         <description>Virtual cluster member state moved</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100622" level="4">
-        <!-- MESGID_VC_DETECT_MEMB_DEAD -->
+    <rule id="100622" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037893$</field>
         <description>Virtual cluster member dead</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100623" level="4">
-        <!-- MESGID_VC_DETECT_MEMB_JOIN -->
+    <rule id="100623" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037894$</field>
         <description>Virtual cluster member joined</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100624" level="4">
-        <!-- MESGID_VC_ADD_HADEV -->
+    <rule id="100624" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037895$</field>
         <description>Virtual cluster added HA device interface</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100625" level="4">
-        <!-- MESGID_VC_DEL_HADEV -->
+    <rule id="100625" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037896$</field>
         <description>Virtual cluster deleted HA device interface</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100626" level="4">
-        <!-- MESGID_HADEV_READY -->
+    <rule id="100626" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037897$</field>
         <description>HA device interface ready</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100627" level="4">
-        <!-- MESGID_HADEV_FAIL -->
+    <rule id="100627" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037898$</field>
         <description>HA device interface failed</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100628" level="4">
-        <!-- MESGID_HADEV_PEERINFO -->
+    <rule id="100628" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037899$</field>
         <description>HA device interface peer information</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100629" level="4">
-        <!-- MESGID_HBDEV_DELETE -->
+    <rule id="100629" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037900$</field>
         <description>Heartbeat device interface deleted</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100630" level="4">
-        <!-- MESGID_HBDEV_DOWN -->
+    <rule id="100630" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037901$</field>
         <description>Heartbeat device interface down</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100631" level="4">
-        <!-- MESGID_HBDEV_UP -->
+    <rule id="100631" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037902$</field>
         <description>Heartbeat device interface up</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.information</group>
     </rule>
 
-    <rule id="100632" level="4">
-        <!-- MESGID_SYNC_STATUS -->
+    <rule id="100632" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037903$</field>
         <description>Synchronization status with primary</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.information</group>
     </rule>
 
-    <rule id="100633" level="4">
-        <!-- MESGID_HA_ACTIVITY -->
+    <rule id="100633" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037904$</field>
         <description>Device set as HA primary</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100634" level="4">
-        <!-- MESGID_VLAN_HB_UP -->
+    <rule id="100634" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037907$</field>
         <description>VLAN heartbeat started</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.information</group>
     </rule>
 
-    <rule id="100635" level="4">
-        <!-- MESGID_VLAN_HB_DOWN -->
+    <rule id="100635" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037908$</field>
         <description>VLAN heartbeat lost</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.error</group>
     </rule>
 
-    <rule id="100636" level="4">
-        <!-- MESGID_VLAN_HB_DOWN_SUM -->
+    <rule id="100636" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037909$</field>
         <description>VLAN heartbeat lost summary</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.error</group>
     </rule>
 
-    <rule id="100637" level="4">
-        <!-- MESGID_HB_PACKET_LOST -->
+    <rule id="100637" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037910$</field>
         <description>Heartbeat packet lost</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100638" level="4">
-        <!-- MESGID_HA_ACTIVITY_INFO -->
+    <rule id="100638" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037911$</field>
         <description>Device set as HA master information</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.information</group>
     </rule>
 
-    <rule id="100639" level="4">
-        <!-- MESGID_FGSP_MEMBER_JOIN -->
+    <rule id="100639" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037912$</field>
         <description>FGSP member joined</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100640" level="4">
-        <!-- MESGID_FGSP_MEMBER_LEAVE -->
+    <rule id="100640" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">037913$</field>
         <description>FGSP member left</description>
         <group>fortios.event.event,fortios.category.ha,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100641" level="4">
-        <!-- LOG_ID_FIPS_ENCRY_FAIL -->
+    <rule id="100641" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038010$</field>
         <description>FIPS CC encryption failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100642" level="4">
-        <!-- LOG_ID_FIPS_DECRY_FAIL -->
+    <rule id="100642" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038011$</field>
         <description>FIPS CC decryption failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100643" level="4">
-        <!-- LOG_ID_ENTROPY_TOKEN -->
+    <rule id="100643" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038012$</field>
         <description>Seeding from entropy source</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100644" level="4">
-        <!-- LOG_ID_FSSO_LOGON -->
+    <rule id="100644" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038031$</field>
         <description>FSSO logon successful</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100645" level="4">
-        <!-- LOG_ID_FSSO_LOGOFF -->
+    <rule id="100645" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038032$</field>
         <description>FSSO logout successful</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100646" level="4">
-        <!-- LOG_ID_FSSO_SVR_STATUS -->
+    <rule id="100646" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038033$</field>
         <description>FSSO Active Directory server authentication status</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100647" level="4">
-        <!-- LOGID_EVENT_NOTIF_INSUFFICIENT_RESOURCE -->
+    <rule id="100647" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038403$</field>
         <description>Insufficient system resource notification</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100648" level="4">
-        <!-- LOGID_EVENT_NOTIF_HOSTNAME_ERROR -->
+    <rule id="100648" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038404$</field>
         <description>FortiGuard hostname unresolvable</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="100649" level="4">
-        <!-- LOGID_NOTIF_CODE_SENDTO_SMS_PHONE -->
+    <rule id="100649" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038405$</field>
         <description>Guest user account login information sent to phone</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100650" level="4">
-        <!-- LOGID_NOTIF_CODE_SENDTO_SMS_TO -->
+    <rule id="100650" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038406$</field>
         <description>Guest user account login information sent as SMS</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100651" level="4">
-        <!-- LOGID_NOTIF_CODE_SENDTO_EMAIL -->
+    <rule id="100651" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038407$</field>
         <description>Guest user account login information sent to email</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100652" level="4">
-        <!-- LOGID_EVENT_OFTP_SSL_CONNECTED -->
+    <rule id="100652" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038408$</field>
         <description>SSL connection established</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100653" level="4">
-        <!-- LOGID_EVENT_OFTP_SSL_DISCONNECTED -->
+    <rule id="100653" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038409$</field>
         <description>SSL connection closed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100654" level="4">
-        <!-- LOGID_EVENT_OFTP_SSL_FAILED -->
+    <rule id="100654" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038410$</field>
         <description>SSL connection failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100655" level="4">
-        <!-- LOGID_EVENT_TWO_F_AUTH_CODE_SENDTO -->
+    <rule id="100655" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038411$</field>
         <description>Two-factor authentication code sent</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100656" level="4">
-        <!-- LOGID_EVENT_TOKEN_CODE_SENDTO -->
+    <rule id="100656" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038412$</field>
         <description>Token activation code sent</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100657" level="4">
-        <!-- LOGID_EVENT_RAD_RPT_PROTO_ERROR -->
+    <rule id="100657" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038656$</field>
         <description>RADIUS protocol error summary</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100658" level="4">
-        <!-- LOGID_EVENT_RAD_RPT_PROF_NOT_FOUND -->
+    <rule id="100658" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038657$</field>
         <description>RADIUS profile not found summary</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100659" level="4">
-        <!-- LOGID_EVENT_RAD_RPT_CTX_NOT_FOUND -->
+    <rule id="100659" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038658$</field>
         <description>RADIUS profile CTX not found summary</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100660" level="4">
-        <!-- LOGID_EVENT_RAD_RPT_ACCT_STOP_MISSED -->
+    <rule id="100660" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038659$</field>
         <description>RADIUS accounting stop message missing summary</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100661" level="4">
-        <!-- LOGID_EVENT_RAD_RPT_ACCT_EVENT -->
+    <rule id="100661" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038660$</field>
         <description>RADIUS accounting event summary</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100662" level="4">
-        <!-- LOGID_EVENT_RAD_RPT_OTHER -->
+    <rule id="100662" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038661$</field>
         <description>RADIUS endpoint block event or other event summary</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100663" level="4">
-        <!-- LOGID_EVENT_RAD_STAT_PROTO_ERROR -->
+    <rule id="100663" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038662$</field>
         <description>RADIUS accounting protocol error</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100664" level="4">
-        <!-- LOGID_EVENT_RAD_STAT_PROF_NOT_FOUND -->
+    <rule id="100664" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038663$</field>
         <description>RADIUS accounting profile not found</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100665" level="4">
-        <!-- LOGID_EVENT_RAD_STAT_ACCT_STOP_MISSED -->
+    <rule id="100665" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038665$</field>
         <description>RADIUS accounting stop message missing</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100666" level="4">
-        <!-- LOGID_EVENT_RAD_STAT_ACCT_EVENT -->
+    <rule id="100666" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038666$</field>
         <description>RADIUS accounting event</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100667" level="4">
-        <!-- LOGID_EVENT_RAD_STAT_OTHER -->
+    <rule id="100667" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038667$</field>
         <description>RADIUS other accounting event</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100668" level="4">
-        <!-- LOGID_EVENT_RAD_STAT_EP_BLK -->
+    <rule id="100668" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">038668$</field>
         <description>RADIUS endpoint block event</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100669" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_USER_TUNNEL_UP -->
+    <rule id="100669" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039424$</field>
         <description>SSL VPN tunnel up</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100670" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_USER_TUNNEL_DOWN -->
+    <rule id="100670" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039425$</field>
         <description>SSL VPN tunnel down</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100671" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_USER_SSL_LOGIN_FAIL -->
+    <rule id="100671" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039426$</field>
         <description>SSL VPN login fail</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100672" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_WEB_TUNNEL_STATS -->
+    <rule id="100672" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039936$</field>
         <description>SSL VPN statistics</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100673" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_WEBAPP_DENY -->
+    <rule id="100673" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039937$</field>
         <description>SSL VPN deny</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100674" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_WEBAPP_PASS -->
+    <rule id="100674" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039938$</field>
         <description>SSL VPN pass</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100675" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_WEBAPP_TIMEOUT -->
+    <rule id="100675" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039939$</field>
         <description>SSL VPN timeout</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100676" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_WEBAPP_CLOSE -->
+    <rule id="100676" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039940$</field>
         <description>SSL VPN close</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100677" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_SYS_BUSY -->
+    <rule id="100677" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039941$</field>
         <description>SSL VPN system busy</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100678" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_CERT_OK -->
+    <rule id="100678" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039942$</field>
         <description>SSL VPN certificate OK</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100679" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_NEW_CON -->
+    <rule id="100679" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039943$</field>
         <description>SSL VPN new connection</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100680" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_ALERT -->
+    <rule id="100680" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039944$</field>
         <description>SSL VPN alert</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100681" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_EXIT_FAIL -->
+    <rule id="100681" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039945$</field>
         <description>SSL VPN exit fail</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100682" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_EXIT_ERR -->
+    <rule id="100682" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039946$</field>
         <description>SSL VPN exit error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100683" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_TUNNEL_UP -->
+    <rule id="100683" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039947$</field>
         <description>SSL VPN tunnel up</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100684" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_TUNNEL_DOWN -->
+    <rule id="100684" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039948$</field>
         <description>SSL VPN tunnel down</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100685" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_TUNNEL_STATS -->
+    <rule id="100685" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039949$</field>
         <description>SSL VPN statistics</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100686" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_TUNNEL_UNKNOWNTAG -->
+    <rule id="100686" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039950$</field>
         <description>SSL VPN unknown tag</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100687" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_TUNNEL_ERROR -->
+    <rule id="100687" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039951$</field>
         <description>SSL VPN tunnel error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100688" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_ENTER_CONSERVE_MODE -->
+    <rule id="100688" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039952$</field>
         <description>SSL VPN enter conserve mode</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100689" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SESSION_LEAVE_CONSERVE_MODE -->
+    <rule id="100689" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">039953$</field>
         <description>SSL VPN leave conserve mode</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100690" level="4">
-        <!-- LOG_ID_PPTP_TUNNEL_UP -->
+    <rule id="100690" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040001$</field>
         <description>PPTP tunnel up</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100691" level="4">
-        <!-- LOG_ID_PPTP_TUNNEL_DOWN -->
+    <rule id="100691" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040002$</field>
         <description>PPTP tunnel down</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100692" level="4">
-        <!-- LOG_ID_PPTP_TUNNEL_STAT -->
+    <rule id="100692" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040003$</field>
         <description>PPTP tunnel status</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100693" level="4">
-        <!-- LOG_ID_PPTP_REACH_MAX_CON -->
+    <rule id="100693" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040014$</field>
         <description>PPTP client connection limit reached</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100694" level="4">
-        <!-- LOG_ID_L2TPD_CLIENT_CON_FAIL -->
+    <rule id="100694" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040017$</field>
         <description>L2TP client connection failed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100695" level="4">
-        <!-- LOG_ID_L2TPD_CLIENT_DISCON -->
+    <rule id="100695" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040019$</field>
         <description>L2TP client disconnected</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100696" level="4">
-        <!-- LOG_ID_PPTP_NOT_CONIG -->
+    <rule id="100696" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040021$</field>
         <description>PPTP not configured in VDOM</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100697" level="4">
-        <!-- LOG_ID_PPTP_NO_IP_AVAIL -->
+    <rule id="100697" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040022$</field>
         <description>PPTP IP addresses unavailable</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100698" level="4">
-        <!-- LOG_ID_PPTP_OUT_MEM -->
+    <rule id="100698" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040024$</field>
         <description>PPTP config list insufficient memory</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100699" level="4">
-        <!-- LOG_ID_PPTP_START -->
+    <rule id="100699" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040034$</field>
         <description>PPTP daemon started</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100700" level="4">
-        <!-- LOG_ID_PPTP_START_FAIL -->
+    <rule id="100700" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040035$</field>
         <description>PPTP daemon failed to start</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.error</group>
     </rule>
 
-    <rule id="100701" level="4">
-        <!-- LOG_ID_PPTP_EXIT -->
+    <rule id="100701" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040036$</field>
         <description>PPTP daemon exited</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100702" level="4">
-        <!-- LOG_ID_PPTPD_SVR_DISCON -->
+    <rule id="100702" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040037$</field>
         <description>PPTP daemon disconnected</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100703" level="4">
-        <!-- LOG_ID_PPTPD_CLIENT_CON -->
+    <rule id="100703" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040038$</field>
         <description>PPTP client connected</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100704" level="4">
-        <!-- LOG_ID_PPTPD_CLIENT_DISCON -->
+    <rule id="100704" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040039$</field>
         <description>PPTP client disconnected</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100705" level="4">
-        <!-- LOG_ID_L2TP_TUNNEL_UP -->
+    <rule id="100705" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040101$</field>
         <description>L2TP tunnel up</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100706" level="4">
-        <!-- LOG_ID_L2TP_TUNNEL_DOWN -->
+    <rule id="100706" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040102$</field>
         <description>L2TP tunnel down</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100707" level="4">
-        <!-- LOG_ID_L2TP_TUNNEL_STAT -->
+    <rule id="100707" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040103$</field>
         <description>L2TP tunnel status</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100708" level="4">
-        <!-- LOG_ID_L2TPD_START -->
+    <rule id="100708" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040114$</field>
         <description>L2TP daemon started</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100709" level="4">
-        <!-- LOG_ID_L2TPD_EXIT -->
+    <rule id="100709" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040115$</field>
         <description>L2TP daemon exited</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100710" level="4">
-        <!-- LOG_ID_L2TPD_CLIENT_CON -->
+    <rule id="100710" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040118$</field>
         <description>L2TP client connected</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100711" level="4">
-        <!-- LOG_ID_EVENT_SYS_PERF -->
+    <rule id="100711" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040704$</field>
         <description>System performance statistics</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100712" level="4">
-        <!-- LOG_ID_EVENT_SYS_CPU_USAGE -->
+    <rule id="100712" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040705$</field>
         <description>CPU usage statistics</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100713" level="4">
-        <!-- LOG_ID_EVENT_SYS_BROKEN_SYMBOLIC_LINK -->
+    <rule id="100713" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040706$</field>
         <description>Delete broken symbolic link</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100714" level="4">
-        <!-- LOG_ID_EVENT_SYS_CPU_USAGE_SINGLE_CORE -->
+    <rule id="100714" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040707$</field>
         <description>CPU single core usage statistics</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100715" level="4">
-        <!-- LOGID_EVENT_WAD_WEBPROXY_FWD_SRV_ERROR -->
+    <rule id="100715" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040960$</field>
         <description>Web proxy forward server error</description>
         <group>fortios.event.event,fortios.category.wad,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100716" level="4">
-        <!-- LOG_ID_UPD_FGT_SUCC -->
+    <rule id="100716" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041000$</field>
         <description>FortiGate update succeeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100717" level="4">
-        <!-- LOG_ID_UPD_FGT_FAIL -->
+    <rule id="100717" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041001$</field>
         <description>FortiGate update failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100718" level="4">
-        <!-- LOG_ID_UPD_SRC_VIS -->
+    <rule id="100718" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041002$</field>
         <description>Source visibility signature package updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100719" level="4">
-        <!-- LOG_ID_UPD_FSA_VIRDB -->
+    <rule id="100719" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041006$</field>
         <description>FortiSandbox AV database updated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100720" level="4">
-        <!-- LOG_ID_UPD_MANUAL_LICENSE_SUCC -->
+    <rule id="100720" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041007$</field>
         <description>FortiGate Manual License update</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100721" level="4">
-        <!-- LOG_ID_UPD_MANUAL_LICENSE_FAIL -->
+    <rule id="100721" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041008$</field>
         <description>FortiGate Manual License is invalid</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100722" level="4">
-        <!-- LOG_ID_UPD_DB_SIGN_INVALID -->
+    <rule id="100722" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041009$</field>
         <description>FortiGate database signature invalid</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100723" level="4">
-        <!-- LOG_ID_UPD_DB_UNSIGNED_INSTALLED -->
+    <rule id="100723" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041011$</field>
         <description>FortiGate database without signature installed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100724" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_LOAD -->
+    <rule id="100724" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041984$</field>
         <description>Certificate loaded</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100725" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_REMOVAL -->
+    <rule id="100725" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041985$</field>
         <description>Certificate removed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100726" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_REGEN -->
+    <rule id="100726" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041986$</field>
         <description>Certificate regenerated</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100727" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_UPDATE -->
+    <rule id="100727" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041987$</field>
         <description>Certificate updated</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100728" level="4">
-        <!-- LOG_ID_EVENT_SSL_VPN_SETTING_UPDATE -->
+    <rule id="100728" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041988$</field>
         <description>SSL setting changed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100729" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_ERR -->
+    <rule id="100729" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041989$</field>
         <description>Certificate error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100730" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_UPDATE_FAILED -->
+    <rule id="100730" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041990$</field>
         <description>Certificate update failed</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100731" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_EXPORT -->
+    <rule id="100731" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041991$</field>
         <description>Certificate exported</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100732" level="4">
-        <!-- LOG_ID_EVENT_VPN_CERT_CRL_EXPIRED -->
+    <rule id="100732" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041992$</field>
         <description>CRL certificate file is expired</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.information</group>
     </rule>
 
-    <rule id="100733" level="4">
-        <!-- LOG_ID_NETX_VMX_ATTACH -->
+    <rule id="100733" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">042201$</field>
         <description>VMX instance successfully attached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100734" level="4">
-        <!-- LOG_ID_NETX_VMX_DETACH -->
+    <rule id="100734" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">042202$</field>
         <description>VMX instance successfully detached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100735" level="4">
-        <!-- LOG_ID_NETX_VMX_DENIED -->
+    <rule id="100735" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">042203$</field>
         <description>VMX instance successfully denied</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100736" level="4">
-        <!-- LOG_ID_EVENT_AUTH_SUCCESS -->
+    <rule id="100736" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043008$</field>
         <description>Authentication success</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100737" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FAILED -->
+    <rule id="100737" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043009$</field>
         <description>Authentication failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100738" level="4">
-        <!-- LOG_ID_EVENT_AUTH_LOCKOUT -->
+    <rule id="100738" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043010$</field>
         <description>Authentication lockout</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100739" level="4">
-        <!-- LOG_ID_EVENT_AUTH_TIME_OUT -->
+    <rule id="100739" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043011$</field>
         <description>Authentication timed out</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100740" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FSAE_LOGON -->
+    <rule id="100740" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043014$</field>
         <description>FSSO logon authentication status</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100741" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FSAE_LOGOFF -->
+    <rule id="100741" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043015$</field>
         <description>FSSO log off authentication status</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100742" level="4">
-        <!-- LOG_ID_EVENT_AUTH_NTLM_AUTH_SUCCESS -->
+    <rule id="100742" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043016$</field>
         <description>NTLM authentication successful</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100743" level="4">
-        <!-- LOG_ID_EVENT_AUTH_NTLM_AUTH_FAIL -->
+    <rule id="100743" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043017$</field>
         <description>NTLM authentication failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100744" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FGOVRD_FAIL -->
+    <rule id="100744" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043018$</field>
         <description>FortiGuard override failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100745" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FGOVRD_SUCCESS -->
+    <rule id="100745" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043020$</field>
         <description>FortiGuard override successful</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100746" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_SUCCESS -->
+    <rule id="100746" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043025$</field>
         <description>Explicit proxy authentication successful</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100747" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_FAILED -->
+    <rule id="100747" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043026$</field>
         <description>Explicit proxy authentication failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100748" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_TIME_OUT -->
+    <rule id="100748" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043027$</field>
         <description>Explicit proxy authentication timed out</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100749" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_GROUP_INFO_FAILED -->
+    <rule id="100749" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043028$</field>
         <description>Explicit proxy user group query failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100750" level="4">
-        <!-- LOG_ID_EVENT_AUTH_WARNING_SUCCESS -->
+    <rule id="100750" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043029$</field>
         <description>FortiGuard authentication override successful</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100751" level="4">
-        <!-- LOG_ID_EVENT_AUTH_WARNING_TBL_FULL -->
+    <rule id="100751" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043030$</field>
         <description>FortiGuard authentication override failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100752" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_USER_LIMIT_REACHED -->
+    <rule id="100752" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043032$</field>
         <description>Explicit proxy authentication user limit reached</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100753" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_MULTIPLE_LOGIN -->
+    <rule id="100753" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043033$</field>
         <description>Explicit proxy authentication user concurrent check failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100754" level="4">
-        <!-- LOG_ID_EVENT_AUTH_PROXY_NO_RESP -->
+    <rule id="100754" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043034$</field>
         <description>Explicit proxy authentication no response</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100755" level="4">
-        <!-- LOG_ID_EVENT_AUTH_IPV4_FLUSH -->
+    <rule id="100755" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043037$</field>
         <description>Authentication IPv4 logon flush</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100756" level="4">
-        <!-- LOG_ID_EVENT_AUTH_IPV6_FLUSH -->
+    <rule id="100756" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043038$</field>
         <description>Authentication IPv6 logon flush</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100757" level="4">
-        <!-- LOG_ID_EVENT_AUTH_LOGON -->
+    <rule id="100757" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043039$</field>
         <description>Authentication logon</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100758" level="4">
-        <!-- LOG_ID_EVENT_AUTH_LOGOUT -->
+    <rule id="100758" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043040$</field>
         <description>Authentication logout</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100759" level="4">
-        <!-- LOG_ID_EVENT_AUTH_DISCLAIMER_ACCEPT -->
+    <rule id="100759" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043041$</field>
         <description>Disclaimer accepted</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100760" level="4">
-        <!-- LOG_ID_EVENT_AUTH_DISCLAIMER_DECLINE -->
+    <rule id="100760" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043042$</field>
         <description>Disclaimer declined</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100761" level="4">
-        <!-- LOG_ID_EVENT_AUTH_EMAIL_COLLECTING_SUCCESS -->
+    <rule id="100761" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043043$</field>
         <description>Email collecting succeeded</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100762" level="4">
-        <!-- LOG_ID_EVENT_AUTH_EMAIL_COLLECTING_FAIL -->
+    <rule id="100762" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043044$</field>
         <description>Email collecting failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100763" level="4">
-        <!-- LOG_ID_EVENT_AUTH_8021X_SUCCESS -->
+    <rule id="100763" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043045$</field>
         <description>802.1x authentication succeeded</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100764" level="4">
-        <!-- LOG_ID_EVENT_AUTH_8021X_FAIL -->
+    <rule id="100764" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043046$</field>
         <description>802.1x authentication failed</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100765" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FSAE_CONNECT -->
+    <rule id="100765" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043050$</field>
         <description>FSSO server connected</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100766" level="4">
-        <!-- LOG_ID_EVENT_AUTH_FSAE_DISCONNECT -->
+    <rule id="100766" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043051$</field>
         <description>FSSO server disconnected</description>
         <group>fortios.event.event,fortios.category.user,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100767" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS -->
+    <rule id="100767" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043520$</field>
         <description>Wireless system activity</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100768" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE -->
+    <rule id="100768" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043521$</field>
         <description>Rogue AP activity</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100769" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP -->
+    <rule id="100769" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043522$</field>
         <description>Physical AP activity</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100770" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA -->
+    <rule id="100770" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043524$</field>
         <description>Wireless client activity</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100771" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ONWIRE -->
+    <rule id="100771" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043525$</field>
         <description>Rogue AP on wire</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100772" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR -->
+    <rule id="100772" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043526$</field>
         <description>Physical AP radio activity</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100773" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_CFG -->
+    <rule id="100773" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043527$</field>
         <description>Rogue AP status configured</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100774" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_ERROR -->
+    <rule id="100774" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043528$</field>
         <description>Physical AP radio error activity</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.error</group>
     </rule>
 
-    <rule id="100775" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_CLB -->
+    <rule id="100775" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043529$</field>
         <description>Wireless client load balancing</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100776" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_WL_BRIDGE -->
+    <rule id="100776" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043530$</field>
         <description>Wireless bridge intrusion detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100777" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_BR_DEAUTH -->
+    <rule id="100777" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043531$</field>
         <description>Wireless broadcasting deauthentication detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100778" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_NL_PBRESP -->
+    <rule id="100778" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043532$</field>
         <description>Wireless null SSID probe response detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100779" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_MAC_OUI -->
+    <rule id="100779" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043533$</field>
         <description>Wireless invalid MAC OUI detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100780" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_LONG_DUR -->
+    <rule id="100780" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043534$</field>
         <description>Wireless long duration attack detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100781" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_WEP_IV -->
+    <rule id="100781" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043535$</field>
         <description>Wireless Weak WEP IV detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100782" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_EAPOL_FLOOD -->
+    <rule id="100782" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043542$</field>
         <description>Wireless EAPOL packet flooding detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100783" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_MGMT_FLOOD -->
+    <rule id="100783" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043544$</field>
         <description>Wireless management flooding detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100784" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_SPOOF_DEAUTH -->
+    <rule id="100784" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043546$</field>
         <description>Wireless spoofed deauthentication detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100785" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WIDS_ASLEAP -->
+    <rule id="100785" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043548$</field>
         <description>Wireless Asleap attack detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100786" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_LOCATE -->
+    <rule id="100786" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043550$</field>
         <description>Wireless station presence detection</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.information</group>
     </rule>
 
-    <rule id="100787" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_JOIN -->
+    <rule id="100787" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043551$</field>
         <description>Physical AP join</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100788" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_LEAVE -->
+    <rule id="100788" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043552$</field>
         <description>Physical AP leave</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100789" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_FAIL -->
+    <rule id="100789" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043553$</field>
         <description>Physical AP fail</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100790" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_UPDATE -->
+    <rule id="100790" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043554$</field>
         <description>Physical AP update</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100791" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_RESET -->
+    <rule id="100791" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043555$</field>
         <description>Physical AP reset</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100792" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_KICK -->
+    <rule id="100792" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043556$</field>
         <description>Physical AP kick</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100793" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_ADD_FAILURE -->
+    <rule id="100793" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043557$</field>
         <description>Physical AP add failure</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100794" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_CFG_ERR -->
+    <rule id="100794" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043558$</field>
         <description>Physical AP config error</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100795" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_SN_MISMATCH -->
+    <rule id="100795" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043559$</field>
         <description>Physical AP SN mismatch</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100796" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS_AC_RESTARTED -->
+    <rule id="100796" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043560$</field>
         <description>Wireless system restarted</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100797" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS_AC_HOSTAPD_UP -->
+    <rule id="100797" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043561$</field>
         <description>Wireless system hostapd up</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100798" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS_AC_HOSTAPD_DOWN -->
+    <rule id="100798" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043562$</field>
         <description>Wireless system hostapd down</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100799" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_DETECT -->
+    <rule id="100799" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043563$</field>
         <description>Rogue AP detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100800" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_OFFAIR -->
+    <rule id="100800" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043564$</field>
         <description>Rogue AP off air</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100801" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_ONAIR -->
+    <rule id="100801" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043565$</field>
         <description>Rogue AP on air</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100802" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_OFFWIRE -->
+    <rule id="100802" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043566$</field>
         <description>Rogue AP off wire</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100803" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_FAKEAP_DETECT -->
+    <rule id="100803" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043567$</field>
         <description>Fake AP detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100804" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_FAKEAP_ONAIR -->
+    <rule id="100804" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043568$</field>
         <description>Fake AP on air</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100805" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_SUPPRESSED -->
+    <rule id="100805" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043569$</field>
         <description>Rogue AP suppressed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100806" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_UNSUPPRESSED -->
+    <rule id="100806" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043570$</field>
         <description>Rogue AP unsuppressed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100807" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_DETECT_CHG -->
+    <rule id="100807" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043571$</field>
         <description>Rogue AP change detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100808" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_ASSO -->
+    <rule id="100808" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043572$</field>
         <description>Wireless client associated</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100809" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_AUTH -->
+    <rule id="100809" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043573$</field>
         <description>Wireless client authenticated</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100810" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DASS -->
+    <rule id="100810" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043574$</field>
         <description>Wireless client disassociated</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100811" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DAUT -->
+    <rule id="100811" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043575$</field>
         <description>Wireless client deauthenticated</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100812" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_IDLE -->
+    <rule id="100812" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043576$</field>
         <description>Wireless client idle</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100813" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DENY -->
+    <rule id="100813" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043577$</field>
         <description>Wireless client denied</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100814" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_KICK -->
+    <rule id="100814" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043578$</field>
         <description>Wireless client kicked</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100815" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_IP -->
+    <rule id="100815" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043579$</field>
         <description>Wireless client IP assigned</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100816" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_LEAVE_WTP -->
+    <rule id="100816" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043580$</field>
         <description>Wireless client left WTP</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100817" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WTP_DISCONN -->
+    <rule id="100817" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043581$</field>
         <description>Wireless client WTP disconnected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100818" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_CFG_UNCLASSIFIED -->
+    <rule id="100818" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043582$</field>
         <description>Rogue AP status configured as unclassified</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100819" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_CFG_ACCEPTED -->
+    <rule id="100819" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043583$</field>
         <description>Rogue AP status configured as accepted</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100820" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_CFG_ROGUE -->
+    <rule id="100820" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043584$</field>
         <description>Rogue AP status configured as rogue</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100821" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ROGUE_CFG_SUPPRESSED -->
+    <rule id="100821" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043585$</field>
         <description>Rogue AP status configured as suppressed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100822" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DARRP_CHAN -->
+    <rule id="100822" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043586$</field>
         <description>Physical AP radio DARRP channel change</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100823" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DARRP_START -->
+    <rule id="100823" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043587$</field>
         <description>Physical AP radio DARRP start</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100824" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_OPER_CHAN -->
+    <rule id="100824" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043588$</field>
         <description>Physical AP radio operation channel change</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100825" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_RADAR -->
+    <rule id="100825" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043589$</field>
         <description>Physical AP radio radar detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100826" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_NOL -->
+    <rule id="100826" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043590$</field>
         <description>Physical AP radio channel removed from NOL</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100827" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_COUNTRY_CFG_SUCCESS -->
+    <rule id="100827" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043591$</field>
         <description>Physical AP radio country config success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100828" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_OPER_COUNTRY -->
+    <rule id="100828" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043592$</field>
         <description>Physical AP radio operation country</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100829" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_CFG_TXPOWER -->
+    <rule id="100829" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043593$</field>
         <description>Physical AP radio config TX power</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100830" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_OPER_TXPOWER -->
+    <rule id="100830" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043594$</field>
         <description>Physical AP radio operation TX power</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100831" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_CLB_DENY -->
+    <rule id="100831" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043595$</field>
         <description>Wireless client load balancing denied</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100832" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_CLB_RETRY -->
+    <rule id="100832" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043596$</field>
         <description>Wireless client load balancing retry</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100833" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_ADD -->
+    <rule id="100833" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043597$</field>
         <description>Physical AP add</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100834" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_ADD_XSS -->
+    <rule id="100834" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043598$</field>
         <description>Physical AP add XSS</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100835" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_DEL -->
+    <rule id="100835" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043599$</field>
         <description>Physical AP delete</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100836" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DARRP_STOP -->
+    <rule id="100836" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043600$</field>
         <description>Physical AP radio DARRP stop</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100837" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_SIGNON -->
+    <rule id="100837" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043601$</field>
         <description>Wireless station sign on</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100838" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_SIGNON_SUCCESS -->
+    <rule id="100838" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043602$</field>
         <description>Wireless station sign on success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100839" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_SIGNON_FAILURE -->
+    <rule id="100839" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043603$</field>
         <description>Wireless station sign on failed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100840" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_EMAIL_REQUEST -->
+    <rule id="100840" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043604$</field>
         <description>Captive-portal VAP e-mail collect request sent</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100841" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_EMAIL_SUCCESS -->
+    <rule id="100841" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043605$</field>
         <description>Captive-portal VAP e-mail collect success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100842" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_EMAIL_FAILURE -->
+    <rule id="100842" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043606$</field>
         <description>Captive-portal VAP e-mail collect failed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100843" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_DISCLAIMER_CHECK -->
+    <rule id="100843" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043607$</field>
         <description>Captive-portal VAP disclaimer agreed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100844" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_DISCLAIMER_DECLINE -->
+    <rule id="100844" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043608$</field>
         <description>Captive-portal VAP disclaimer declined</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100845" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DARRP_OPTIMIZATION_START -->
+    <rule id="100845" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043609$</field>
         <description>DARRP optimization start</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100846" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DARRP_OPTIMIZATION_STOP -->
+    <rule id="100846" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043610$</field>
         <description>DARRP optimization stop</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100847" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS_AC_UP -->
+    <rule id="100847" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043611$</field>
         <description>Wireless controller start</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100848" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS_AC_CFG_LOADED -->
+    <rule id="100848" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043612$</field>
         <description>Wireless controller configuration loaded</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100849" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_ERR -->
+    <rule id="100849" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043613$</field>
         <description>Physical AP error</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100850" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_DHCP_STAVATION -->
+    <rule id="100850" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043614$</field>
         <description>DHCP Starvation detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100851" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SYS_AC_IPSEC_FAIL -->
+    <rule id="100851" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043615$</field>
         <description>Wireless controller IPsec setup failed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100852" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_NOL_ADD -->
+    <rule id="100852" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043616$</field>
         <description>Physical AP radio NOL added</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100853" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_IMAGE_RC_SUCCESS -->
+    <rule id="100853" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043618$</field>
         <description>Physical AP image receive success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100854" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_OFFENDINGAP_DETECT -->
+    <rule id="100854" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043619$</field>
         <description>Offending AP detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100855" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_OFFENDINGAP_ONAIR -->
+    <rule id="100855" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043620$</field>
         <description>Offending AP on air</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100856" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_DATA_CHAN_CHG -->
+    <rule id="100856" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043621$</field>
         <description>Wireless wtp data channel changed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100857" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_VLAN_PROBE -->
+    <rule id="100857" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043622$</field>
         <description>WTP is probing vlan</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100858" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_VLAN_MISSING -->
+    <rule id="100858" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043623$</field>
         <description>VLAN not detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100859" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_VLAN_DETECTED -->
+    <rule id="100859" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043624$</field>
         <description>VLAN detected</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100860" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_CMCC_SUCCESS -->
+    <rule id="100860" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043625$</field>
         <description>Wireless station CMCC sign on success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100861" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_CMCC_FAILURE -->
+    <rule id="100861" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043626$</field>
         <description>Wireless station CMCC sign on failed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100862" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_CMCC_TIMEOUT -->
+    <rule id="100862" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043627$</field>
         <description>Wireless station CMCC sign on timeout</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100863" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_CAP_CMCC_MAC_AUTH_SUCCESS -->
+    <rule id="100863" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043628$</field>
         <description>Wireless station CMCC MAC auth success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100864" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_RADIUS_AUTH_FAILURE -->
+    <rule id="100864" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043629$</field>
         <description>Wireless client RADIUS authentication failure</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100865" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_RADIUS_AUTH_SUCCESS -->
+    <rule id="100865" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043630$</field>
         <description>Wireless client RADIUS authentication success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100866" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_RADIUS_AUTH_NO_RESP -->
+    <rule id="100866" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043631$</field>
         <description>Wireless client RADIUS authentication server not responding</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100867" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_RADIUS_MAC_AUTH_FAILURE -->
+    <rule id="100867" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043632$</field>
         <description>Wireless client RADIUS MAC authentication failure</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100868" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_RADIUS_MAC_AUTH_SUCCESS -->
+    <rule id="100868" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043633$</field>
         <description>Wireless client RADIUS MAC authentication success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100869" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_RADIUS_MAC_AUTH_NO_RESP -->
+    <rule id="100869" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043634$</field>
         <description>Wireless client RADIUS MAC authentication server not responding</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100870" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_OKC_NO_MATCH -->
+    <rule id="100870" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043635$</field>
         <description>Wireless client authenticates through OKC failed with no match</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100871" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_OKC_LOCAL_MATCH -->
+    <rule id="100871" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043636$</field>
         <description>Wireless client authenticates through local OKC success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100872" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_OKC_INTER_AC_MATCH -->
+    <rule id="100872" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043637$</field>
         <description>Wireless client authenticates through inter AC OKC success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100873" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_OKC_INTER_AP_MATCH -->
+    <rule id="100873" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043638$</field>
         <description>Wireless client authenticates through inter AP OKC success</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100874" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_INVALID_ACTION_REQ -->
+    <rule id="100874" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043639$</field>
         <description>Wireless client sent invalid FT action request</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100875" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_INVALID_AUTH_REQ -->
+    <rule id="100875" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043640$</field>
         <description>Wireless client sent invalid FT auth request</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100876" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_INVALID_REASSOC_REQ -->
+    <rule id="100876" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043641$</field>
         <description>Wireless client sent invalid FT reassociation request</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100877" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_ACTION_REQ -->
+    <rule id="100877" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043642$</field>
         <description>Wireless client sent FT action reqeust</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100878" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_ACTION_RESP -->
+    <rule id="100878" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043643$</field>
         <description>FT action response was sent to wireless client</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100879" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_AUTH_REQ -->
+    <rule id="100879" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043644$</field>
         <description>Wireless client sent FT auth request</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100880" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_AUTH_RESP -->
+    <rule id="100880" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043645$</field>
         <description>FT auth response was sent to wireless client</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100881" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_REASSOC_REQ -->
+    <rule id="100881" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043646$</field>
         <description>Wireless client sent FT reassociation request</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100882" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_FT_REASSOC_RESP -->
+    <rule id="100882" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043647$</field>
         <description>FT reassociation response was sent to wireless client</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100883" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_INVALID_SECOND_MSG -->
+    <rule id="100883" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043648$</field>
         <description>Wireless client 4 way handshake failed with invalid 2/4 message</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100884" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_INVALID_FOURTH_MSG -->
+    <rule id="100884" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043649$</field>
         <description>Wireless client 4 way handshake failed with invalid 4/4 message</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100885" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_FIRST_MSG -->
+    <rule id="100885" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043650$</field>
         <description>AP sent 1/4 message of 4 way handshake to wireless client</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100886" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_SECOND_MSG -->
+    <rule id="100886" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043651$</field>
         <description>Wireless client sent 2/4 message of 4 way handshake</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100887" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_THIRD_MSG -->
+    <rule id="100887" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043652$</field>
         <description>AP sent 3/4 message of 4 way handshake to wireless client</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100888" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_FOURTH_MSG -->
+    <rule id="100888" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043653$</field>
         <description>Wireless client sent 4/4 message of 4 way handshake</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100889" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_FIRST_GROUP_MSG -->
+    <rule id="100889" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043654$</field>
         <description>AP sent 1/2 message of group key handshake to wireless client</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100890" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_SECOND_GROUP_MSG -->
+    <rule id="100890" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043655$</field>
         <description>Wireless client sent 2/2 message of group key handshake</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100891" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_MAX_STA_CNT -->
+    <rule id="100891" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043656$</field>
         <description>Max sta count limit for the PSK was reached</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100892" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_ASSOC_FAIL -->
+    <rule id="100892" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043657$</field>
         <description>Wireless station association failed</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100893" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_NO_RESP -->
+    <rule id="100893" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043658$</field>
         <description>Wireless station DHCP process failed with no server response</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100894" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_DIFF_OFFER -->
+    <rule id="100894" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043659$</field>
         <description>Another DHCP server sent DHCP offer to wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100895" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_NO_ACK -->
+    <rule id="100895" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043660$</field>
         <description>No DHCP ACK from server</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100896" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_NAK -->
+    <rule id="100896" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043661$</field>
         <description>DHCP server sent DHCP NAK</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100897" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_DUP_IP -->
+    <rule id="100897" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043662$</field>
         <description>IP offered has been used by another wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100898" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_DISCOVER -->
+    <rule id="100898" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043663$</field>
         <description>Wireless station sent DHCP DISCOVER</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100899" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_OFFER -->
+    <rule id="100899" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043664$</field>
         <description>DHCP server sent DHCP OFFER</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100900" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_DECLINE -->
+    <rule id="100900" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043665$</field>
         <description>Wireless station sent DHCP DECLINE</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100901" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_REQUEST -->
+    <rule id="100901" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043666$</field>
         <description>Wireless station sent DHCP REQUEST</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100902" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_ACK -->
+    <rule id="100902" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043667$</field>
         <description>DHCP server sent DHCP ACK</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100903" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_RELEASE -->
+    <rule id="100903" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043668$</field>
         <description>Wireless station sent DHCP RELEASE</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100904" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_INFORM -->
+    <rule id="100904" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043669$</field>
         <description>Wireless station sent DHCP INFORM</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100905" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_SELF_ASSIGNED -->
+    <rule id="100905" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043670$</field>
         <description>Wireless station is using self-assigned IP</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100906" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DNS_NO_RESP -->
+    <rule id="100906" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043671$</field>
         <description>Wireless station DNS process failed with no server response</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100907" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DNS_SERVER_FAILURE -->
+    <rule id="100907" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043672$</field>
         <description>Wireless station DNS process failed due to server failure</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100908" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DNS_NO_DOMAIN -->
+    <rule id="100908" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043673$</field>
         <description>Wireless station DNS process failed due to non-existing domain</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100909" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_KRACK_FT_REASSOC -->
+    <rule id="100909" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043674$</field>
         <description>Wireless station WPA key reinstallation attack on FT reassociation</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100910" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_AUTH_REQ -->
+    <rule id="100910" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043675$</field>
         <description>Authentication request from wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100911" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_AUTH_RESP -->
+    <rule id="100911" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043676$</field>
         <description>Authentication response to wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100912" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_ASSOC_REQ -->
+    <rule id="100912" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043677$</field>
         <description>Association request from wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100913" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_REASSOC_REQ -->
+    <rule id="100913" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043678$</field>
         <description>Reassociation request from wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100914" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_ASSOC_RESP -->
+    <rule id="100914" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043679$</field>
         <description>Association response to wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100915" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_REASSOC_RESP -->
+    <rule id="100915" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043680$</field>
         <description>Reassociation response to wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100916" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_PROBE_REQ -->
+    <rule id="100916" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043681$</field>
         <description>Probe request from wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.information</group>
     </rule>
 
-    <rule id="100917" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_PROBE_RESP -->
+    <rule id="100917" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043682$</field>
         <description>Probe response to wireless station</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.information</group>
     </rule>
 
-    <rule id="100918" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_BLE_DEV_LOCATE -->
+    <rule id="100918" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043683$</field>
         <description>Wireless ble dev detection</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.information</group>
     </rule>
 
-    <rule id="100919" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ADDRGRP_DUPLICATE_MAC -->
+    <rule id="100919" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043684$</field>
         <description>Wireless addrgrp duplicate mac</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100920" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ADDRGRP_ADDR_APPLY -->
+    <rule id="100920" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043685$</field>
         <description>Wireless addrgrp address apply</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100921" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WPA_MSG_INVALID_SCHEDULE -->
+    <rule id="100921" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043686$</field>
         <description>PSK is out of any valid schedules</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100922" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WL_BRIDGE_TRAFFIC_STATS -->
+    <rule id="100922" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043687$</field>
         <description>Traffic stats for station with bridge wlan</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.information</group>
     </rule>
 
-    <rule id="100923" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_APCFG_RECEIVE -->
+    <rule id="100923" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043688$</field>
         <description>FortiAP receives the apcfg</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100924" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_APCFG_VALIDATING -->
+    <rule id="100924" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043689$</field>
         <description>FortiAP is validating the apcfg</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100925" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_APCFG_APPLY -->
+    <rule id="100925" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043690$</field>
         <description>FortiAP applies the apcfg</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100926" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_APCFG_REJECT -->
+    <rule id="100926" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043691$</field>
         <description>FortiAP rejects the apcfg</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100927" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_ANTENNA_DEFECT_DETECT -->
+    <rule id="100927" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043692$</field>
         <description>Defect antenna detection</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100928" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WNM_ACTION_BSTM_REQ -->
+    <rule id="100928" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043693$</field>
         <description>AP sent WNM action BSTM request</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100929" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WNM_ACTION_BSTM_RESP_ACCEPT -->
+    <rule id="100929" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043694$</field>
         <description>Wireless client sent WNM action BSTM response accept</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100930" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_WNM_ACTION_BSTM_RESP_REJECT -->
+    <rule id="100930" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043695$</field>
         <description>Wireless client sent WNM action BSTM response reject</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100931" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DRMA_START -->
+    <rule id="100931" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043696$</field>
         <description>Physical AP radio DRMA start</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100932" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DRMA_STOP -->
+    <rule id="100932" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043697$</field>
         <description>Physical AP radio DRMA stop</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100933" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_DRMA_MODE -->
+    <rule id="100933" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043698$</field>
         <description>Physical AP radio DRMA mode</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100934" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_SOLICIT -->
+    <rule id="100934" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043699$</field>
         <description>Wireless station sent DHCP6 SOLICIT</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100935" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_ADVERTISE -->
+    <rule id="100935" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043700$</field>
         <description>DHCP6 server sent DHCP6 ADVERTISE</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100936" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_REQUEST -->
+    <rule id="100936" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043701$</field>
         <description>Wireless station sent DHCP6 REQUEST</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100937" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_CONFIRM -->
+    <rule id="100937" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043702$</field>
         <description>Wireless station sent DHCP6 CONFIRM</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100938" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_RENEW -->
+    <rule id="100938" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043703$</field>
         <description>Wireless station sent DHCP6 RENEW</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100939" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_REPLY -->
+    <rule id="100939" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043704$</field>
         <description>DHCP6 server sent DHCP6 REPLY</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100940" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_RELEASE -->
+    <rule id="100940" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043705$</field>
         <description>Wireless station sent DHCP6 RELEASE</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100941" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP6_RECONFIGURE -->
+    <rule id="100941" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043706$</field>
         <description>DHCP6 server sent DHCP6 RECONFIGURE</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100942" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_SSID_UP -->
+    <rule id="100942" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043707$</field>
         <description>Physical AP radio ssid up</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100943" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_SSID_DOWN -->
+    <rule id="100943" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043708$</field>
         <description>Physical AP radio ssid down</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100944" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_DHCP_ENFORCEMENT -->
+    <rule id="100944" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043709$</field>
         <description>Wireless client denied by DHCP enforcement for using static IP address</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100945" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SAM_IPERF -->
+    <rule id="100945" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043710$</field>
         <description>SAM iperf test result</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100946" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SAM_PING -->
+    <rule id="100946" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043711$</field>
         <description>SAM ping test result</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100947" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SAM_AUTH_FAILED -->
+    <rule id="100947" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043712$</field>
         <description>AP as station failed in SAM authentication</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100948" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_SAM_CWP_AUTH_FAILED -->
+    <rule id="100948" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043713$</field>
         <description>AP as station failed in SAM CWP authentication</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100949" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTP_PARTIAL_PASSWD -->
+    <rule id="100949" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043714$</field>
         <description>AP received partial login password</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100950" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_WTPR_BSS_COLOR_COLLISION -->
+    <rule id="100950" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043715$</field>
         <description>AP radio BSS color collision detected.</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100951" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_ADDRGRP_MAX_FW_ADDR -->
+    <rule id="100951" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043716$</field>
         <description>Wireless addrgrp reached firewal address maximum number</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100952" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_L3R_REHOME -->
+    <rule id="100952" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043717$</field>
         <description>Wireless client layer3 roaming rehome</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100953" level="4">
-        <!-- LOG_ID_EVENT_WIRELESS_STA_PROBE_LOW_RSSI -->
+    <rule id="100953" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043719$</field>
         <description>Probe request from wireless station failed due to low rssi</description>
         <group>fortios.event.event,fortios.category.wireless,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100954" level="4">
-        <!-- LOG_ID_EVENT_NAC_QUARANTINE -->
+    <rule id="100954" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043776$</field>
         <description>NAC quarantine</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100955" level="4">
-        <!-- LOG_ID_EVENT_NAC_ANOMALY_QUARANTINE -->
+    <rule id="100955" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043777$</field>
         <description>NAC anomaly quarantine</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100956" level="4">
-        <!-- LOG_ID_EVENT_ELBC_BLADE_JOIN -->
+    <rule id="100956" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043800$</field>
         <description>Blade ready to process traffic</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100957" level="4">
-        <!-- LOG_ID_EVENT_ELBC_BLADE_LEAVE -->
+    <rule id="100957" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043801$</field>
         <description>Blade not ready to process traffic</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100958" level="4">
-        <!-- LOG_ID_EVENT_ELBC_MASTER_BLADE_FOUND -->
+    <rule id="100958" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043802$</field>
         <description>Primary blade found</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100959" level="4">
-        <!-- LOG_ID_EVENT_ELBC_MASTER_BLADE_LOST -->
+    <rule id="100959" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043803$</field>
         <description>Primary blade lost</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100960" level="4">
-        <!-- LOG_ID_EVENT_ELBC_MASTER_BLADE_CHANGE -->
+    <rule id="100960" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043804$</field>
         <description>Primary blade changed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100961" level="4">
-        <!-- LOG_ID_EVENT_ELBC_ACTIVE_CHANNEL_FOUND -->
+    <rule id="100961" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043805$</field>
         <description>ELBC channel active</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100962" level="4">
-        <!-- LOG_ID_EVENT_ELBC_ACTIVE_CHANNEL_LOST -->
+    <rule id="100962" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043806$</field>
         <description>ELBC channel inactive</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100963" level="4">
-        <!-- LOG_ID_EVENT_ELBC_ACTIVE_CHANNEL_CHANGE -->
+    <rule id="100963" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043807$</field>
         <description>ELBC channel failover</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100964" level="4">
-        <!-- LOG_ID_EVENT_ELBC_CHASSIS_ACTIVE -->
+    <rule id="100964" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043808$</field>
         <description>ELBC chassis active</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100965" level="4">
-        <!-- LOG_ID_EVENT_ELBC_CHASSIS_INACTIVE -->
+    <rule id="100965" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">043809$</field>
         <description>ELBC chassis inactive</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="100966" level="4">
-        <!-- LOGID_EVENT_CONFIG_PATH -->
+    <rule id="100966" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044544$</field>
         <description>Path configured</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100967" level="4">
-        <!-- LOGID_EVENT_CONFIG_OBJ -->
+    <rule id="100967" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044545$</field>
         <description>Object configured</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100968" level="4">
-        <!-- LOGID_EVENT_CONFIG_ATTR -->
+    <rule id="100968" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044546$</field>
         <description>Attribute configured</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100969" level="4">
-        <!-- LOGID_EVENT_CONFIG_OBJATTR -->
+    <rule id="100969" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044547$</field>
         <description>Object attribute configured</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100970" level="4">
-        <!-- LOGID_EVENT_CONFIG_EXEC -->
+    <rule id="100970" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044548$</field>
         <description>Action performed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="100971" level="4">
-        <!-- LOGID_EVENT_CMDB_DEADLOCK_DETECTED -->
+    <rule id="100971" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044555$</field>
         <description>CMDB lock deadlock is detected.</description>
@@ -7702,7 +7702,7 @@
     </rule>
 
     <rule id="100972" level="4">
-        <!-- LOG_ID_FCC_ADD -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">045057$</field>
         <description>FortiClient connection added</description>
@@ -7710,7 +7710,7 @@
     </rule>
 
     <rule id="100973" level="4">
-        <!-- LOG_ID_FCC_CLOSE -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">045058$</field>
         <description>FortiClient connection closed</description>
@@ -7718,599 +7718,599 @@
     </rule>
 
     <rule id="100974" level="4">
-        <!-- LOG_ID_FCC_CLOSE_BY_TYPE -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">045061$</field>
         <description>FortiClient connection closed by type</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.information</group>
     </rule>
 
-    <rule id="100975" level="4">
-        <!-- LOG_ID_FCC_VULN_SCAN -->
+    <rule id="100975" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045071$</field>
         <description>FortiClient Vulnerability Scan</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100976" level="4">
-        <!-- LOG_ID_EC_REG_QUARANTINE -->
+    <rule id="100976" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045114$</field>
         <description>FortiClient endpoint quarantined</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100977" level="4">
-        <!-- LOG_ID_EC_REG_UNQUARANTINE -->
+    <rule id="100977" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045115$</field>
         <description>FortiClient endpoint quarantine removed</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100978" level="4">
-        <!-- LOG_ID_EC_EMS_WS_NOTIFICATION -->
+    <rule id="100978" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045121$</field>
         <description>EMS WebSocket notification</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100979" level="4">
-        <!-- LOG_ID_EC_EMS_REST_API_ERROR -->
+    <rule id="100979" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045122$</field>
         <description>EMS REST API error</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100980" level="4">
-        <!-- LOG_ID_EC_EMS_WS_CONN_ERROR -->
+    <rule id="100980" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045123$</field>
         <description>EMS WebSocket connection error</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100981" level="4">
-        <!-- LOG_ID_EC_VPND_CONNECT -->
+    <rule id="100981" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045124$</field>
         <description>FortiClient VPN connected</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100982" level="4">
-        <!-- LOG_ID_EC_VPND_DISCONNECT -->
+    <rule id="100982" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045125$</field>
         <description>FortiClient VPN disconnected</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100983" level="4">
-        <!-- LOG_ID_EC_CLOUD_ENTITLEMENT_LOST -->
+    <rule id="100983" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045126$</field>
         <description>EMS Cloud entitlement lost and connection dropped</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100984" level="4">
-        <!-- LOG_ID_EC_EMS_REST_API_NEW_SUCCESS -->
+    <rule id="100984" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045128$</field>
         <description>EMS REST API recovered from an error</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.information</group>
     </rule>
 
-    <rule id="100985" level="4">
-        <!-- LOG_ID_EC_EMS_EMS_VERIFY -->
+    <rule id="100985" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045129$</field>
         <description>FCEMS entry has been verified</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.information</group>
     </rule>
 
-    <rule id="100986" level="4">
-        <!-- LOG_ID_EC_EMS_EMS_VERIFY_FAILED -->
+    <rule id="100986" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045130$</field>
         <description>FCEMS entry has failed to be verified</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="100987" level="4">
-        <!-- LOG_ID_EC_EMS_EMS_UNVERIFY -->
+    <rule id="100987" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045131$</field>
         <description>FCEMS entry has been unverified</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.information</group>
     </rule>
 
-    <rule id="100988" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_ENA -->
+    <rule id="100988" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046000$</field>
         <description>VIP real server enabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100989" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_DISA -->
+    <rule id="100989" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046001$</field>
         <description>VIP real server disabled</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100990" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_UP -->
+    <rule id="100990" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046002$</field>
         <description>VIP real server up</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100991" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_DOWN -->
+    <rule id="100991" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046003$</field>
         <description>VIP real server down</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100992" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_ENT_HOLDDOWN -->
+    <rule id="100992" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046004$</field>
         <description>VIP real server entered hold-down</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100993" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_FAIL_HOLDDOWN -->
+    <rule id="100993" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046005$</field>
         <description>VIP real server health check failed during hold-down</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.alert</group>
     </rule>
 
-    <rule id="100994" level="4">
-        <!-- LOG_ID_VIP_REAL_SVR_FAIL -->
+    <rule id="100994" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046006$</field>
         <description>VIP real server health check failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.debug</group>
     </rule>
 
-    <rule id="100995" level="4">
-        <!-- LOG_ID_EVENT_EXT_SYS -->
+    <rule id="100995" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046400$</field>
         <description>FortiExtender system activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100996" level="4">
-        <!-- LOG_ID_EVENT_EXT_LOCAL -->
+    <rule id="100996" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046401$</field>
         <description>FortiExtender controller activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.notice</group>
     </rule>
 
-    <rule id="100997" level="4">
-        <!-- LOG_ID_EVENT_EXT_LOCAL_ERROR -->
+    <rule id="100997" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046402$</field>
         <description>FortiExtender controller activity error</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.error</group>
     </rule>
 
-    <rule id="100998" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_EMERG -->
+    <rule id="100998" level="15">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046403$</field>
         <description>Remote FortiExtender emergency activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.emergency</group>
     </rule>
 
-    <rule id="100999" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_ALERT -->
+    <rule id="100999" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046404$</field>
         <description>Remote FortiExtender alert activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.alert</group>
     </rule>
 
-    <rule id="101000" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_CRITICAL -->
+    <rule id="101000" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046405$</field>
         <description>Remote FortiExtender critical activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101001" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_ERROR -->
+    <rule id="101001" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046406$</field>
         <description>Remote FortiExtender error activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.error</group>
     </rule>
 
-    <rule id="101002" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_WARNING -->
+    <rule id="101002" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046407$</field>
         <description>Remote FortiExtender warning activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101003" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_NOTIF -->
+    <rule id="101003" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046408$</field>
         <description>Remote FortiExtender notify activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101004" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_INFO -->
+    <rule id="101004" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046409$</field>
         <description>Remote FortiExtender info activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.information</group>
     </rule>
 
-    <rule id="101005" level="4">
-        <!-- LOG_ID_EVENT_EXT_REMOTE_DEBUG -->
+    <rule id="101005" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046410$</field>
         <description>Remote FortiExtender debug activity</description>
         <group>fortios.event.event,fortios.category.fortiextender,fortios.severity.debug</group>
     </rule>
 
-    <rule id="101006" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_DETECTION -->
+    <rule id="101006" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046501$</field>
         <description>LTE modem detection</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101007" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_GPSD -->
+    <rule id="101007" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046502$</field>
         <description>LTE modem GPS daemon started or stopped</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101008" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_GPS_LOC_ACQUISITION -->
+    <rule id="101008" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046503$</field>
         <description>LTE modem GPS location acquisition</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101009" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLD -->
+    <rule id="101009" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046504$</field>
         <description>LTE modem billing daemon started or stopped</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101010" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLING_PURGED -->
+    <rule id="101010" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046505$</field>
         <description>LTE billing data purged</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101011" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLING_DAILY_LOG -->
+    <rule id="101011" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046506$</field>
         <description>LTE billing daily usage information</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101012" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_FW_UPGRADE -->
+    <rule id="101012" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046507$</field>
         <description>LTE modem firmware upgrade event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101013" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_QDL_DETECTION -->
+    <rule id="101013" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046508$</field>
         <description>LTE modem QDL device detection event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101014" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_REBOOT -->
+    <rule id="101014" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046509$</field>
         <description>LTE modem reboot event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101015" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_OP_MODE -->
+    <rule id="101015" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046510$</field>
         <description>LTE modem operation mode</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101016" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_POWER_ON_OFF -->
+    <rule id="101016" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046511$</field>
         <description>LTE modem powered on or powered off</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101017" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_SIM_STATE -->
+    <rule id="101017" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046512$</field>
         <description>LTE modem sim card state event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101018" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_LINK_CONNECTION -->
+    <rule id="101018" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046513$</field>
         <description>LTE modem data link connection event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101019" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_MANUAL_HANDOVER -->
+    <rule id="101019" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046514$</field>
         <description>LTE modem manual handover event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101020" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_IP_ADDR -->
+    <rule id="101020" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046515$</field>
         <description>LTE modem ip address event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101021" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BEARER_TECH_CHANGE -->
+    <rule id="101021" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046516$</field>
         <description>LTE modem bearer event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101022" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_WRONG_PIN -->
+    <rule id="101022" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046517$</field>
         <description>LTE unlock SIM PIM failed.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101023" level="4">
-        <!-- LOG_ID_EVENT_AUTOMATION_TRIGGERED -->
+    <rule id="101023" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046600$</field>
         <description>Automation stitch triggered</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101024" level="4">
-        <!-- LOG_ID_POE_STATUS_REPORT -->
+    <rule id="101024" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046900$</field>
         <description>PoE device status reported</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="101025" level="4">
-        <!-- LOG_ID_MALWARE_LIST_TRUNCATED_ENTER -->
+    <rule id="101025" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047000$</field>
         <description>External blocklist list is truncated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101026" level="4">
-        <!-- LOG_ID_MALWARE_LIST_TRUNCATED_EXIT -->
+    <rule id="101026" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047001$</field>
         <description>External blocklist list is no longer truncated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101027" level="4">
-        <!-- LOG_ID_FILE_HASH_EMS_LIST_TRUNCATED_ENTER -->
+    <rule id="101027" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047002$</field>
         <description>EMS file-hash list is truncated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101028" level="4">
-        <!-- LOG_ID_FILE_HASH_EMS_LIST_TRUNCATED_EXIT -->
+    <rule id="101028" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047003$</field>
         <description>EMS file-hash list is no longer truncated</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101029" level="4">
-        <!-- LOG_ID_FILE_HASH_EMS_LIST_LOAD -->
+    <rule id="101029" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047004$</field>
         <description>EMS file-hash list loaded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101030" level="4">
-        <!-- LOG_ID_ENTER_BYPASS -->
+    <rule id="101030" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047203$</field>
         <description>Bypass ports pair entered bypass mode</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101031" level="4">
-        <!-- LOG_ID_EXIT_BYPASS -->
+    <rule id="101031" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047204$</field>
         <description>Bypass ports pair exited bypass mode</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101032" level="4">
-        <!-- LOG_ID_EVENT_REST_API_OK -->
+    <rule id="101032" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047301$</field>
         <description>REST API request success</description>
         <group>fortios.event.event,fortios.category.rest-api,fortios.severity.information</group>
     </rule>
 
-    <rule id="101033" level="4">
-        <!-- LOG_ID_EVENT_REST_API_ERR -->
+    <rule id="101033" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">047302$</field>
         <description>REST API request failed</description>
         <group>fortios.event.event,fortios.category.rest-api,fortios.severity.error</group>
     </rule>
 
-    <rule id="101034" level="4">
-        <!-- LOG_ID_WAD_WANOPT_TUNNEL_CREATE -->
+    <rule id="101034" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">048040$</field>
         <description>WANOPT Tunnel successfully created</description>
         <group>fortios.event.event,fortios.category.wad,fortios.severity.information</group>
     </rule>
 
-    <rule id="101035" level="4">
-        <!-- LOG_ID_WAD_WANOPT_TUNNEL_CLOSED -->
+    <rule id="101035" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">048041$</field>
         <description>WANOPT Tunnel closed</description>
         <group>fortios.event.event,fortios.category.wad,fortios.severity.information</group>
     </rule>
 
-    <rule id="101036" level="4">
-        <!-- LOG_ID_WAD_AUTH_FAIL_PSK -->
+    <rule id="101036" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">048101$</field>
         <description>WAN Optimization peer PSK authentication failed</description>
         <group>fortios.event.event,fortios.category.wad,fortios.severity.error</group>
     </rule>
 
-    <rule id="101037" level="4">
-        <!-- LOG_ID_WAD_AUTH_FAIL_OTH -->
+    <rule id="101037" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">048102$</field>
         <description>WAN Optimization peer authentication failed</description>
         <group>fortios.event.event,fortios.category.wad,fortios.severity.error</group>
     </rule>
 
-    <rule id="101038" level="4">
-        <!-- LOG_ID_UNEXP_APP_TYPE -->
+    <rule id="101038" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">048301$</field>
         <description>Unexpected application type for WAN Optimization</description>
         <group>fortios.event.event,fortios.category.wad,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101039" level="4">
-        <!-- LOG_ID_VNP_DPDK_PRIMARY_RESTART -->
+    <rule id="101039" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">049002$</field>
         <description>VNP Primary restarted</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101040" level="4">
-        <!-- LOGID_EVENT_HYPERV_SRIOV_SHOW_UP -->
+    <rule id="101040" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">049004$</field>
         <description>Hyper-V SR-IOV VF secondary is hot plugged</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101041" level="4">
-        <!-- LOGID_EVENT_HYPERV_SRIOV_DISAPPEAR -->
+    <rule id="101041" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">049005$</field>
         <description>Hyper-V SR-IOV VF secondary is hot unplugged</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101042" level="4">
-        <!-- LOG_ID_NB_TBL_CHG -->
+    <rule id="101042" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">051000$</field>
         <description>Neighbor table changed</description>
         <group>fortios.event.event,fortios.category.router,fortios.severity.information</group>
     </rule>
 
-    <rule id="101043" level="4">
-        <!-- LOG_ID_EVENT_SECURITY_AUDIT_FABRIC_SUMMARY -->
+    <rule id="101043" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">052000$</field>
         <description>Security Rating summary</description>
         <group>fortios.event.event,fortios.category.security-rating,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101044" level="4">
-        <!-- LOG_ID_EVENT_SECURITY_AUDIT_FABRIC_CHANGE -->
+    <rule id="101044" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">052001$</field>
         <description>Security Rating result change</description>
         <group>fortios.event.event,fortios.category.security-rating,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101045" level="4">
-        <!-- LOG_ID_SDNC_CONNECTED -->
+    <rule id="101045" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053000$</field>
         <description>Connected to SDN server</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101046" level="4">
-        <!-- LOG_ID_SDNC_DISCONNECTED -->
+    <rule id="101046" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053001$</field>
         <description>Disconnected from SDN server</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101047" level="4">
-        <!-- LOG_ID_SDNC_SUBSCRIBE -->
+    <rule id="101047" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053002$</field>
         <description>Dynamic SDN address channel opened</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101048" level="4">
-        <!-- LOG_ID_SDNC_UNSUBSCRIBE -->
+    <rule id="101048" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053003$</field>
         <description>Dynamic SDN address channel closed</description>
@@ -8318,7 +8318,7 @@
     </rule>
 
     <rule id="101049" level="4">
-        <!-- LOG_ID_VPN_OCVPN_REGISTERED -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053100$</field>
         <description>Overlay Controller VPN registered</description>
@@ -8326,7 +8326,7 @@
     </rule>
 
     <rule id="101050" level="4">
-        <!-- LOG_ID_VPN_OCVPN_UNREGISTERED -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053101$</field>
         <description>Overlay Controller VPN unregistered</description>
@@ -8334,7 +8334,7 @@
     </rule>
 
     <rule id="101051" level="4">
-        <!-- LOG_ID_VPN_OCVPN_COMM_ESTABLISHED -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053102$</field>
         <description>Overlay Controller VPN server communication established</description>
@@ -8342,7 +8342,7 @@
     </rule>
 
     <rule id="101052" level="4">
-        <!-- LOG_ID_VPN_OCVPN_COMM_ERROR -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053103$</field>
         <description>Overlay Controller VPN server communication error</description>
@@ -8350,7 +8350,7 @@
     </rule>
 
     <rule id="101053" level="4">
-        <!-- LOG_ID_VPN_OCVPN_DNS_ERROR -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053104$</field>
         <description>Overlay Controller VPN DNS error</description>
@@ -8358,135 +8358,135 @@
     </rule>
 
     <rule id="101054" level="4">
-        <!-- LOG_ID_VPN_OCVPN_ROUTE_ERROR -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053105$</field>
         <description>Overlay Controller VPN routing error</description>
         <group>fortios.event.event,fortios.category.vpn,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101055" level="4">
-        <!-- LOG_ID_CONNECTOR_OBJECT_ADD -->
+    <rule id="101055" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053200$</field>
         <description>Dynamic address added</description>
         <group>fortios.event.event,fortios.category.connector,fortios.severity.information</group>
     </rule>
 
-    <rule id="101056" level="4">
-        <!-- LOG_ID_CONNECTOR_OBJECT_REMOVE -->
+    <rule id="101056" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053201$</field>
         <description>Dynamic address removed</description>
         <group>fortios.event.event,fortios.category.connector,fortios.severity.information</group>
     </rule>
 
-    <rule id="101057" level="4">
-        <!-- LOG_ID_CONNECTOR_API_FAILED -->
+    <rule id="101057" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053202$</field>
         <description>SDN Connector API failed</description>
         <group>fortios.event.event,fortios.category.connector,fortios.severity.error</group>
     </rule>
 
-    <rule id="101058" level="4">
-        <!-- LOG_ID_CONNECTOR_OBJECT_UPDATE -->
+    <rule id="101058" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053203$</field>
         <description>Dynamic address updated.</description>
         <group>fortios.event.event,fortios.category.connector,fortios.severity.information</group>
     </rule>
 
-    <rule id="101059" level="4">
-        <!-- LOG_ID_CONNECTOR_OBJECT_CANT_ADD -->
+    <rule id="101059" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053204$</field>
         <description>Dynamic address can't be added</description>
         <group>fortios.event.event,fortios.category.connector,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101060" level="4">
-        <!-- LOG_ID_CONNECTOR_OBJECT_CANT_REMOVE -->
+    <rule id="101060" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053205$</field>
         <description>Dynamic address can't be removed</description>
         <group>fortios.event.event,fortios.category.connector,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101061" level="4">
-        <!-- LOG_ID_VNE_PRO_UPDATE_COMPLETED -->
+    <rule id="101061" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053300$</field>
         <description>VNE provision server update completed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101062" level="4">
-        <!-- LOG_ID_VNE_PRO_UPDATE_FAILED -->
+    <rule id="101062" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053301$</field>
         <description>VNE provision server update failed</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101063" level="4">
-        <!-- LOG_ID_NPU_PER_MAPPING_ALLOCATION -->
+    <rule id="101063" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053311$</field>
         <description>Resource per mapping allocation</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101064" level="4">
-        <!-- LOG_ID_NPD_INFO -->
+    <rule id="101064" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053312$</field>
         <description>NPD INFO</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101065" level="4">
-        <!-- LOG_ID_NPD_WARNING -->
+    <rule id="101065" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053313$</field>
         <description>NPD WARNING MSG</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101066" level="4">
-        <!-- LOG_ID_NPD_ERROR -->
+    <rule id="101066" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053314$</field>
         <description>NPD ERROR MSG</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="101067" level="4">
-        <!-- LOG_ID_LPM_ERROR -->
+    <rule id="101067" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053315$</field>
         <description>LPM ERROR MSG</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.error</group>
     </rule>
 
-    <rule id="101068" level="4">
-        <!-- LOG_ID_LPM_INFO -->
+    <rule id="101068" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053316$</field>
         <description>LPM INFO MSG</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101069" level="4">
-        <!-- LOG_ID_FMG_TUNNEL_UP -->
+    <rule id="101069" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053400$</field>
         <description>Central Management connectivity is active</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101070" level="4">
-        <!-- LOG_ID_FMG_TUNNEL_DOWN -->
+    <rule id="101070" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053401$</field>
         <description>Central Management connectivity is inactive</description>
@@ -8494,935 +8494,935 @@
     </rule>
 
     <rule id="101071" level="4">
-        <!-- LOG_ID_DP_RX_DROP_DETECTED -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">053405$</field>
         <description>DP channel RX drop detected.</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101072" level="4">
-        <!-- LOG_ID_2GB_CSF_UPGRADE -->
+    <rule id="101072" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053406$</field>
         <description>Security Fabric settings changed during upgrade</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101073" level="4">
-        <!-- LOG_ID_CIFS_CONN_FAIL -->
+    <rule id="101073" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">063002$</field>
         <description>Unable to connect to the CIFS Domain Controller</description>
         <group>fortios.event.event,fortios.category.cifs-auth-fail,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101074" level="4">
-        <!-- LOG_ID_CIFS_AUTH_FAIL -->
+    <rule id="101074" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">063003$</field>
         <description>Unable to authenticate with the CIFS Domain Controller</description>
         <group>fortios.event.event,fortios.category.cifs-auth-fail,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101075" level="4">
-        <!-- LOG_ID_CIFS_AUTH_INTERNAL_ERROR -->
+    <rule id="101075" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">063004$</field>
         <description>An error occurred in processing CIFS authentication</description>
         <group>fortios.event.event,fortios.category.cifs-auth-fail,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101076" level="4">
-        <!-- LOG_ID_CIFS_AUTH_KRB_ERROR -->
+    <rule id="101076" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">063005$</field>
         <description>An error occurred in processing CIFS authentication.</description>
         <group>fortios.event.event,fortios.category.cifs-auth-fail,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101077" level="4">
-        <!-- LOG_ID_FILE_FILTER_BLOCK -->
+    <rule id="101077" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">064000$</field>
         <description>File was blocked by file filter</description>
         <group>fortios.event.file-filter,fortios.category.file-filter,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101078" level="4">
-        <!-- LOG_ID_FILE_FILTER_LOG -->
+    <rule id="101078" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">064001$</field>
         <description>File was detected by file filter</description>
         <group>fortios.event.file-filter,fortios.category.file-filter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101079" level="4">
-        <!-- LOG_ID_FSW_FLOW -->
+    <rule id="101079" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">056001$</field>
         <description>LOG_ID_FSW_FLOW</description>
         <group>fortios.event.forti-switch,fortios.category.fsw-flow,fortios.severity.information</group>
     </rule>
 
-    <rule id="101080" level="4">
-        <!-- LOGID_GTP_FORWARD -->
+    <rule id="101080" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041216$</field>
         <description>GTP forward</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101081" level="4">
-        <!-- LOGID_GTP_DENY -->
+    <rule id="101081" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041217$</field>
         <description>GTP deny</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101082" level="4">
-        <!-- LOGID_GTP_RATE_LIMIT -->
+    <rule id="101082" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041218$</field>
         <description>GTP rate limit</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101083" level="4">
-        <!-- LOGID_GTP_STATE_INVALID -->
+    <rule id="101083" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041219$</field>
         <description>GTP state invalid</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101084" level="4">
-        <!-- LOGID_GTP_TUNNEL_LIMIT -->
+    <rule id="101084" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041220$</field>
         <description>Tunnel limit GTP message. These messages occur only when the maximum number of GTP</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101085" level="4">
-        <!-- LOGID_GTP_TRAFFIC_COUNT -->
+    <rule id="101085" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041221$</field>
         <description>Statistic summary information when the GTP tunnel is being torn down</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101086" level="4">
-        <!-- LOGID_GTP_USER_DATA -->
+    <rule id="101086" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041222$</field>
         <description>GTP user data</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101087" level="4">
-        <!-- LOGID_GTPV2_FORWARD -->
+    <rule id="101087" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041223$</field>
         <description>GTPv2 forward message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101088" level="4">
-        <!-- LOGID_GTPV2_DENY -->
+    <rule id="101088" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041224$</field>
         <description>GTPv2 deny message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101089" level="4">
-        <!-- LOGID_GTPV2_RATE_LIMIT -->
+    <rule id="101089" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041225$</field>
         <description>GTPv2 rate limit message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101090" level="4">
-        <!-- LOGID_GTPV2_STATE_INVALID -->
+    <rule id="101090" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041226$</field>
         <description>GTPv2 state invalid message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101091" level="4">
-        <!-- LOGID_GTPV2_TUNNEL_LIMIT -->
+    <rule id="101091" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041227$</field>
         <description>Tunnel limit GTP (version 2) message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101092" level="4">
-        <!-- LOGID_GTPV2_TRAFFIC_COUNT -->
+    <rule id="101092" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041228$</field>
         <description>Statistic summary information when the GTPv2 tunnel is being torn down</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101093" level="4">
-        <!-- LOGID_GTPU_FORWARD -->
+    <rule id="101093" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041229$</field>
         <description>GTPU forward message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101094" level="4">
-        <!-- LOGID_GTPU_DENY -->
+    <rule id="101094" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041230$</field>
         <description>GTPU deny message</description>
         <group>fortios.event.gtp,fortios.category.gtp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101095" level="4">
-        <!-- LOGID_PFCP_FORWARD -->
+    <rule id="101095" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041231$</field>
         <description>PFCP forward message</description>
         <group>fortios.event.gtp,fortios.category.pfcp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101096" level="4">
-        <!-- LOGID_PFCP_DENY -->
+    <rule id="101096" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041232$</field>
         <description>PFCP deny message</description>
         <group>fortios.event.gtp,fortios.category.pfcp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101097" level="4">
-        <!-- LOGID_PFCP_TRAFFIC_COUNT -->
+    <rule id="101097" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">041233$</field>
         <description>Statistic summary information when the PFCP session is being torn down</description>
         <group>fortios.event.gtp,fortios.category.pfcp-all,fortios.severity.information</group>
     </rule>
 
-    <rule id="101098" level="4">
-        <!-- LOG_ID_ICAP_SERVER_ERROR -->
+    <rule id="101098" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">060000$</field>
         <description>Traffic blocked as it cannot be forwarded to ICAP Server.</description>
         <group>fortios.event.icap,fortios.category.icap,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101099" level="4">
-        <!-- LOG_ID_ICAP_INFECTION_BLOCK -->
+    <rule id="101099" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">060001$</field>
         <description>Traffic blocked as ICAP server found infection.</description>
         <group>fortios.event.icap,fortios.category.icap,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101100" level="4">
-        <!-- LOG_ID_ICAP_SERVER_CLOSE_CONN -->
+    <rule id="101100" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">060002$</field>
         <description>Traffic dropped as ICAP server connection is closed.</description>
         <group>fortios.event.icap,fortios.category.icap,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101101" level="4">
-        <!-- LOGID_ATTCK_SIGNATURE_TCP_UDP -->
+    <rule id="101101" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">016384$</field>
         <description>Attack detected by UDP/TCP signature</description>
         <group>fortios.event.ips,fortios.category.signature,fortios.severity.alert</group>
     </rule>
 
-    <rule id="101102" level="4">
-        <!-- LOGID_ATTCK_SIGNATURE_ICMP -->
+    <rule id="101102" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">016385$</field>
         <description>Attack detected by ICMP signature</description>
         <group>fortios.event.ips,fortios.category.signature,fortios.severity.alert</group>
     </rule>
 
-    <rule id="101103" level="4">
-        <!-- LOGID_ATTCK_SIGNATURE_OTHERS -->
+    <rule id="101103" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">016386$</field>
         <description>Attack detected by other signature</description>
         <group>fortios.event.ips,fortios.category.signature,fortios.severity.alert</group>
     </rule>
 
-    <rule id="101104" level="4">
-        <!-- LOGID_ATTACK_MALICIOUS_URL -->
+    <rule id="101104" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">016399$</field>
         <description>Attack detected by a malicious URL</description>
         <group>fortios.event.ips,fortios.category.malicious-url,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101105" level="4">
-        <!-- LOGID_ATTACK_BOTNET_WARNING -->
+    <rule id="101105" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">016400$</field>
         <description>Botnet C&amp;C Communication (warning)</description>
         <group>fortios.event.ips,fortios.category.botnet,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101106" level="4">
-        <!-- LOGID_ATTACK_BOTNET_NOTIF -->
+    <rule id="101106" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">016401$</field>
         <description>Botnet C&amp;C Communication (notice)</description>
         <group>fortios.event.ips,fortios.category.botnet,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101107" level="4">
-        <!-- LOG_ID_SSH_COMMAND_BLOCK -->
+    <rule id="101107" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061000$</field>
         <description>SSH shell command is blocked</description>
         <group>fortios.event.ssh,fortios.category.ssh-command,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101108" level="4">
-        <!-- LOG_ID_SSH_COMMAND_BLOCK_ALERT -->
+    <rule id="101108" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061001$</field>
         <description>SSH shell command is blocked</description>
         <group>fortios.event.ssh,fortios.category.ssh-command,fortios.severity.alert</group>
     </rule>
 
-    <rule id="101109" level="4">
-        <!-- LOG_ID_SSH_COMMAND_PASS -->
+    <rule id="101109" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061002$</field>
         <description>SSH shell command is detected</description>
         <group>fortios.event.ssh,fortios.category.ssh-command,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101110" level="4">
-        <!-- LOG_ID_SSH_COMMAND_PASS_ALERT -->
+    <rule id="101110" level="14">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061003$</field>
         <description>SSH shell command is detected</description>
         <group>fortios.event.ssh,fortios.category.ssh-command,fortios.severity.alert</group>
     </rule>
 
-    <rule id="101111" level="4">
-        <!-- LOG_ID_SSH_CHANNEL_BLOCK -->
+    <rule id="101111" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061010$</field>
         <description>SSH channel is blocked</description>
         <group>fortios.event.ssh,fortios.category.ssh-channel,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101112" level="4">
-        <!-- LOG_ID_SSH_CHANNEL_PASS -->
+    <rule id="101112" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061011$</field>
         <description>SSH channel is detected</description>
         <group>fortios.event.ssh,fortios.category.ssh-channel,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101113" level="4">
-        <!-- LOG_ID_SSH_HOST_KEY_WARNING -->
+    <rule id="101113" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061012$</field>
         <description>SSH connection is blocked, because host-key is not trust</description>
         <group>fortios.event.ssh,fortios.category.ssh-hostkey,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101114" level="4">
-        <!-- LOG_ID_SSH_HOST_KEY_NOTIF -->
+    <rule id="101114" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">061013$</field>
         <description>SSH host-key is not trust</description>
         <group>fortios.event.ssh,fortios.category.ssh-hostkey,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101115" level="4">
-        <!-- LOG_ID_SSL_EXEMPT_ADDR -->
+    <rule id="101115" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062004$</field>
         <description>SSL connection is exempted based on address</description>
         <group>fortios.event.ssl,fortios.category.ssl-exempt,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101116" level="4">
-        <!-- LOG_ID_SSL_EXEMPT_ALLOWLIST -->
+    <rule id="101116" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062006$</field>
         <description>SSL connection is exempted based on allowlist</description>
         <group>fortios.event.ssl,fortios.category.ssl-exempt,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101117" level="4">
-        <!-- LOG_ID_SSL_EXEMPT_FTGD_CATEGORY -->
+    <rule id="101117" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062007$</field>
         <description>SSL connection is exempted based on FortiGuard category rating</description>
         <group>fortios.event.ssl,fortios.category.ssl-exempt,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101118" level="4">
-        <!-- LOG_ID_SSL_EXEMPT_LOCAL_CATEGORY -->
+    <rule id="101118" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062008$</field>
         <description>SSL connection is exempted based on local category rating</description>
         <group>fortios.event.ssl,fortios.category.ssl-exempt,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101119" level="4">
-        <!-- LOG_ID_SSL_EXEMPT_USER_CATEGORY -->
+    <rule id="101119" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062009$</field>
         <description>SSL connection is exempted based on user category rating</description>
         <group>fortios.event.ssl,fortios.category.ssl-exempt,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101120" level="4">
-        <!-- LOG_ID_SSL_NEGOTIATION_INSPECT -->
+    <rule id="101120" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062100$</field>
         <description>Continue inspect the SSL connection</description>
         <group>fortios.event.ssl,fortios.category.ssl-negotiation,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101121" level="4">
-        <!-- LOG_ID_SSL_NEGOTIATION_BLOCK -->
+    <rule id="101121" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062101$</field>
         <description>SSL connection is blocked due to its SSL negotiation</description>
         <group>fortios.event.ssl,fortios.category.ssl-negotiation,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101122" level="4">
-        <!-- LOG_ID_SSL_NEGOTIATION_BYPASS -->
+    <rule id="101122" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062102$</field>
         <description>SSL connection is bypassed due to its SSL negotiation</description>
         <group>fortios.event.ssl,fortios.category.ssl-negotiation,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101123" level="4">
-        <!-- LOG_ID_SSL_NEGOTIATION_INFO -->
+    <rule id="101123" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062103$</field>
         <description>SSL connection information</description>
         <group>fortios.event.ssl,fortios.category.ssl-negotiation,fortios.severity.information</group>
     </rule>
 
-    <rule id="101124" level="4">
-        <!-- LOG_ID_SSL_SERVER_CERT_INFO -->
+    <rule id="101124" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062200$</field>
         <description>SSL server certificate information</description>
         <group>fortios.event.ssl,fortios.category.ssl-server-cert-info,fortios.severity.information</group>
     </rule>
 
-    <rule id="101125" level="4">
-        <!-- LOG_ID_SSL_HANDSHAKE_INFO -->
+    <rule id="101125" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062220$</field>
         <description>SSL handshake information</description>
         <group>fortios.event.ssl,fortios.category.ssl-handshake,fortios.severity.information</group>
     </rule>
 
-    <rule id="101126" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_BLOCKLISTED -->
+    <rule id="101126" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062300$</field>
         <description>SSL connection is blocked due to the server certificate is blocklisted</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101127" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_RESIGN_TRUSTED -->
+    <rule id="101127" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062301$</field>
         <description>Server certificate has security problem</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101128" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_RESIGN_UNTRUSTED -->
+    <rule id="101128" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062302$</field>
         <description>Re-signed server certificate as untrusted due to security problem</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101129" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_BLOCKED -->
+    <rule id="101129" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062303$</field>
         <description>SSL connection is blocked due to server certificate security problem</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101130" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_SNI_MISMATCHED -->
+    <rule id="101130" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062304$</field>
         <description>SSL connection is blocked due to server certificate and SNI mismatched</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101131" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_PROBE_FAILURE_BLOCK -->
+    <rule id="101131" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062305$</field>
         <description>SSL connection is blocked due to unable to retrieve server's certificate</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101132" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_PROBE_FAILURE_PASS -->
+    <rule id="101132" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062306$</field>
         <description>SSL connection is bypassed due to unable to retrieve server's certificate</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101133" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_SNI_MISMATCHED_INFO -->
+    <rule id="101133" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062307$</field>
         <description>Server certificate and SNI mismatched</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.information</group>
     </rule>
 
-    <rule id="101134" level="4">
-        <!-- LOG_ID_TRAFFIC_ALLOW -->
+    <rule id="101134" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000002$</field>
         <description>Allowed traffic</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101135" level="4">
-        <!-- LOG_ID_TRAFFIC_DENY -->
+    <rule id="101135" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000003$</field>
         <description>Traffic violation</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101136" level="4">
-        <!-- LOG_ID_TRAFFIC_OTHER_START -->
+    <rule id="101136" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000004$</field>
         <description>Traffic other session start</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101137" level="4">
-        <!-- LOG_ID_TRAFFIC_OTHER_ICMP_ALLOW -->
+    <rule id="101137" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000005$</field>
         <description>Traffic allowed ICMP</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101138" level="4">
-        <!-- LOG_ID_TRAFFIC_OTHER_ICMP_DENY -->
+    <rule id="101138" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000006$</field>
         <description>Traffic denied ICMP</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101139" level="4">
-        <!-- LOG_ID_TRAFFIC_OTHER_INVALID -->
+    <rule id="101139" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000007$</field>
         <description>Traffic other invalid</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101140" level="4">
-        <!-- LOG_ID_TRAFFIC_WANOPT -->
+    <rule id="101140" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000008$</field>
         <description>WAN optimization traffic</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101141" level="4">
-        <!-- LOG_ID_TRAFFIC_WEBCACHE -->
+    <rule id="101141" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000009$</field>
         <description>Web cache traffic</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101142" level="4">
-        <!-- LOG_ID_TRAFFIC_EXPLICIT_PROXY -->
+    <rule id="101142" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000010$</field>
         <description>Explicit proxy traffic</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101143" level="4">
-        <!-- LOG_ID_TRAFFIC_FAIL_CONN -->
+    <rule id="101143" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000011$</field>
         <description>Failed connection attempts</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101144" level="4">
-        <!-- LOG_ID_TRAFFIC_MULTICAST -->
+    <rule id="101144" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000012$</field>
         <description>Multicast traffic</description>
         <group>fortios.event.traffic,fortios.category.multicast,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101145" level="4">
-        <!-- LOG_ID_TRAFFIC_END_FORWARD -->
+    <rule id="101145" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000013$</field>
         <description>Forward traffic</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101146" level="4">
-        <!-- LOG_ID_TRAFFIC_END_LOCAL -->
+    <rule id="101146" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000014$</field>
         <description>Local traffic</description>
         <group>fortios.event.traffic,fortios.category.local,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101147" level="4">
-        <!-- LOG_ID_TRAFFIC_START_FORWARD -->
+    <rule id="101147" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000015$</field>
         <description>Forward traffic session start</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101148" level="4">
-        <!-- LOG_ID_TRAFFIC_START_LOCAL -->
+    <rule id="101148" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000016$</field>
         <description>Local traffic session start</description>
         <group>fortios.event.traffic,fortios.category.local,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101149" level="4">
-        <!-- LOG_ID_TRAFFIC_SNIFFER -->
+    <rule id="101149" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000017$</field>
         <description>Sniffer traffic</description>
         <group>fortios.event.traffic,fortios.category.sniffer,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101150" level="4">
-        <!-- LOG_ID_TRAFFIC_BROADCAST -->
+    <rule id="101150" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000019$</field>
         <description>Broadcast traffic</description>
         <group>fortios.event.traffic,fortios.category.multicast,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101151" level="4">
-        <!-- LOG_ID_TRAFFIC_STAT -->
+    <rule id="101151" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000020$</field>
         <description>Forward traffic statistics</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101152" level="4">
-        <!-- LOG_ID_TRAFFIC_SNIFFER_STAT -->
+    <rule id="101152" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000021$</field>
         <description>Sniffer traffic statistics</description>
         <group>fortios.event.traffic,fortios.category.sniffer,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101153" level="4">
-        <!-- LOG_ID_TRAFFIC_UTM_CORRELATION -->
+    <rule id="101153" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000022$</field>
         <description>Forward traffic for UTM correlation</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101154" level="4">
-        <!-- LOG_ID_TRAFFIC_ZTNA -->
+    <rule id="101154" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000024$</field>
         <description>ZTNA traffic</description>
         <group>fortios.event.traffic,fortios.category.ztna,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101155" level="4">
-        <!-- LOG_ID_TRAFFIC_SFLOW -->
+    <rule id="101155" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">000025$</field>
         <description>Sflow sample</description>
         <group>fortios.event.traffic,fortios.category.forward,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101156" level="4">
-        <!-- MESGID_INFECT_WARNING -->
+    <rule id="101156" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08192$</field>
         <description>Infected file detected by the FortiGate unit and blocked</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101157" level="4">
-        <!-- MESGID_INFECT_NOTIF -->
+    <rule id="101157" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08193$</field>
         <description>Infected file detected by the FortiGate unit and it passed</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101158" level="4">
-        <!-- MESGID_INFECT_MIME_WARNING -->
+    <rule id="101158" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08194$</field>
         <description>MIME header detected to have a virus and blocked</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101159" level="4">
-        <!-- MESGID_INFECT_MIME_NOTIF -->
+    <rule id="101159" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08195$</field>
         <description>MIME header infected and passed</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101160" level="4">
-        <!-- MESGID_MIME_FILETYPE_EXE_WARNING -->
+    <rule id="101160" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08200$</field>
         <description>File is an executable (warning)</description>
         <group>fortios.event.virus,fortios.category.filetype-executable,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101161" level="4">
-        <!-- MESGID_MIME_FILETYPE_EXE_NOTIF -->
+    <rule id="101161" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08201$</field>
         <description>File is an executable (notice)</description>
         <group>fortios.event.virus,fortios.category.filetype-executable,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101162" level="4">
-        <!-- MESGID_AVQUERY_WARNING -->
+    <rule id="101162" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08202$</field>
         <description>File reported infected by Outbreak Prevention (warning)</description>
         <group>fortios.event.virus,fortios.category.outbreak-prevention,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101163" level="4">
-        <!-- MESGID_AVQUERY_NOTIF -->
+    <rule id="101163" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08203$</field>
         <description>File reported infected by Outbreak Prevention (notice)</description>
         <group>fortios.event.virus,fortios.category.outbreak-prevention,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101164" level="4">
-        <!-- MESGID_MIME_AVQUERY_WARNING -->
+    <rule id="101164" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08204$</field>
         <description>MIME data reported infected by Outbreak Prevention (warning)</description>
         <group>fortios.event.virus,fortios.category.outbreak-prevention,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101165" level="4">
-        <!-- MESGID_MIME_AVQUERY_NOTIF -->
+    <rule id="101165" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08205$</field>
         <description>MIME data reported infected by Outbreak Prevention (notice)</description>
         <group>fortios.event.virus,fortios.category.outbreak-prevention,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101166" level="4">
-        <!-- MESGID_AV_EXEMPT_NOTIF -->
+    <rule id="101166" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08206$</field>
         <description>File reported matched AV exempt list (notice)</description>
         <group>fortios.event.virus,fortios.category.exempt-hash,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101167" level="4">
-        <!-- MESGID_MIME_AV_EXEMPT_NOTIF -->
+    <rule id="101167" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08207$</field>
         <description>MIME data reported matched AV exempt list (notice)</description>
         <group>fortios.event.virus,fortios.category.exempt-hash,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101168" level="4">
-        <!-- MESGID_MALWARE_LIST_WARNING -->
+    <rule id="101168" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08212$</field>
         <description>File reported infected by external malware list (warning)</description>
         <group>fortios.event.virus,fortios.category.malware-list,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101169" level="4">
-        <!-- MESGID_MALWARE_LIST_NOTIF -->
+    <rule id="101169" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08213$</field>
         <description>File reported infected by external malware list (notice)</description>
         <group>fortios.event.virus,fortios.category.malware-list,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101170" level="4">
-        <!-- MESGID_MIME_MALWARE_LIST_WARNING -->
+    <rule id="101170" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08214$</field>
         <description>MIME data reported infected by external malware list (warning)</description>
         <group>fortios.event.virus,fortios.category.malware-list,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101171" level="4">
-        <!-- MESGID_MIME_MALWARE_LIST_NOTIF -->
+    <rule id="101171" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08215$</field>
         <description>MIME data reported infected by external malware list (notice)</description>
         <group>fortios.event.virus,fortios.category.malware-list,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101172" level="4">
-        <!-- MESGID_FILE_HASH_EMS_WARNING -->
+    <rule id="101172" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08216$</field>
         <description>File reported infected by EMS threat feed (warning)</description>
         <group>fortios.event.virus,fortios.category.ems-threat-feed,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101173" level="4">
-        <!-- MESGID_FILE_HASH_EMS_NOTIF -->
+    <rule id="101173" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08217$</field>
         <description>File reported infected by EMS threat feed (notice)</description>
         <group>fortios.event.virus,fortios.category.ems-threat-feed,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101174" level="4">
-        <!-- MESGID_MIME_FILE_HASH_EMS_WARNING -->
+    <rule id="101174" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08218$</field>
         <description>MIME data reported infected by EMS threat feed (warning)</description>
         <group>fortios.event.virus,fortios.category.ems-threat-feed,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101175" level="4">
-        <!-- MESGID_MIME_FILE_HASH_EMS_NOTIF -->
+    <rule id="101175" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08219$</field>
         <description>MIME data reported infected by EMS threat feed (notice)</description>
         <group>fortios.event.virus,fortios.category.ems-threat-feed,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101176" level="4">
-        <!-- MESGID_FAI_WARNING -->
+    <rule id="101176" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08220$</field>
         <description>File reported infected by FortiNDR (warning)</description>
         <group>fortios.event.virus,fortios.category.fortindr,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101177" level="4">
-        <!-- MESGID_FAI_NOTIF -->
+    <rule id="101177" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08221$</field>
         <description>File reported infected by FortiNDR (notice)</description>
         <group>fortios.event.virus,fortios.category.fortindr,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101178" level="4">
-        <!-- MESGID_MIME_FAI_WARNING -->
+    <rule id="101178" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08222$</field>
         <description>MIME data reported infected by FortiNDR (warning)</description>
         <group>fortios.event.virus,fortios.category.fortindr,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101179" level="4">
-        <!-- MESGID_MIME_FAI_NOTIF -->
+    <rule id="101179" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08223$</field>
         <description>MIME data reported infected by FortiNDR (notice)</description>
         <group>fortios.event.virus,fortios.category.fortindr,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101180" level="4">
-        <!-- MESGID_ICB_TIMEOUT_WARNING -->
+    <rule id="101180" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08224$</field>
         <description>Inline Block scan timeout (warning)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101181" level="4">
-        <!-- MESGID_ICB_TIMEOUT_NOTIF -->
+    <rule id="101181" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08225$</field>
         <description>Inline Block scan timeout (notice)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101182" level="4">
-        <!-- MESGID_MIME_ICB_TIMEOUT_WARNING -->
+    <rule id="101182" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08226$</field>
         <description>MIME data reported Inline Block scan timeout (warning)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101183" level="4">
-        <!-- MESGID_MIME_ICB_TIMEOUT_NOTIF -->
+    <rule id="101183" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08227$</field>
         <description>MIME data reported Inline Block scan timeout (notice)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101184" level="4">
-        <!-- MESGID_ICB_ERROR_WARNING -->
+    <rule id="101184" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08228$</field>
         <description>Inline Block scan error (warning)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101185" level="4">
-        <!-- MESGID_ICB_ERROR_NOTIF -->
+    <rule id="101185" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08229$</field>
         <description>Inline Block scan error (notice)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101186" level="4">
-        <!-- MESGID_MIME_ICB_ERROR_WARNING -->
+    <rule id="101186" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08230$</field>
         <description>MIME data reported Inline Block scan error (warning)</description>
         <group>fortios.event.virus,fortios.category.inline-block,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101187" level="4">
-        <!-- MESGID_MIME_ICB_ERROR_NOTIF -->
+    <rule id="101187" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08231$</field>
         <description>MIME data reported Inline Block scan error (notice)</description>
@@ -9430,7 +9430,7 @@
     </rule>
 
     <rule id="101188" level="4">
-        <!-- MESGID_ICB_FSA_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08232$</field>
         <description>File reported infected by FortiSandbox (warning)</description>
@@ -9438,7 +9438,7 @@
     </rule>
 
     <rule id="101189" level="4">
-        <!-- MESGID_ICB_FSA_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08233$</field>
         <description>File reported infected by FortiSandbox (notice)</description>
@@ -9446,7 +9446,7 @@
     </rule>
 
     <rule id="101190" level="4">
-        <!-- MESGID_MIME_ICB_FSA_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08234$</field>
         <description>MIME data reported infected by FortiSandbox (warning)</description>
@@ -9454,7 +9454,7 @@
     </rule>
 
     <rule id="101191" level="4">
-        <!-- MESGID_MIME_ICB_FSA_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08235$</field>
         <description>MIME data reported infected by FortiSandbox (notice)</description>
@@ -9462,7 +9462,7 @@
     </rule>
 
     <rule id="101192" level="4">
-        <!-- MESGID_ICB_FSA_TIMEOUT_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08236$</field>
         <description>FortiSandbox scan timeout (warning)</description>
@@ -9470,7 +9470,7 @@
     </rule>
 
     <rule id="101193" level="4">
-        <!-- MESGID_ICB_FSA_TIMEOUT_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08237$</field>
         <description>FortiSandbox scan timeout (notice)</description>
@@ -9478,7 +9478,7 @@
     </rule>
 
     <rule id="101194" level="4">
-        <!-- MESGID_MIME_ICB_FSA_TIMEOUT_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08238$</field>
         <description>MIME data reported FortiSandbox scan timeout (warning)</description>
@@ -9486,7 +9486,7 @@
     </rule>
 
     <rule id="101195" level="4">
-        <!-- MESGID_MIME_ICB_FSA_TIMEOUT_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08239$</field>
         <description>MIME data reported FortiSandbox scan timeout (notice)</description>
@@ -9494,7 +9494,7 @@
     </rule>
 
     <rule id="101196" level="4">
-        <!-- MESGID_ICB_FSA_ERROR_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08240$</field>
         <description>FortiSandbox scan error (warning)</description>
@@ -9502,7 +9502,7 @@
     </rule>
 
     <rule id="101197" level="4">
-        <!-- MESGID_ICB_FSA_ERROR_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08241$</field>
         <description>FortiSandbox scan error (notice)</description>
@@ -9510,7 +9510,7 @@
     </rule>
 
     <rule id="101198" level="4">
-        <!-- MESGID_MIME_ICB_FSA_ERROR_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08242$</field>
         <description>MIME data reported FortiSandbox scan error (warning)</description>
@@ -9518,903 +9518,903 @@
     </rule>
 
     <rule id="101199" level="4">
-        <!-- MESGID_MIME_ICB_FSA_ERROR_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08243$</field>
         <description>MIME data reported FortiSandbox scan error (notice)</description>
         <group>fortios.event.virus,fortios.category.fortisandbox,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101200" level="4">
-        <!-- MESGID_BLOCK_WARNING -->
+    <rule id="101200" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08448$</field>
         <description>FortiGate unit blocked a file because it contains a virus</description>
         <group>fortios.event.virus,fortios.category.filename,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101201" level="4">
-        <!-- MESGID_BLOCK_MIME_WARNING -->
+    <rule id="101201" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08450$</field>
         <description>FortiGate unit blocked a file because it contains a virus (MIME)</description>
         <group>fortios.event.virus,fortios.category.mimefragmented,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101202" level="4">
-        <!-- MESGID_BLOCK_MIME_NOTIF -->
+    <rule id="101202" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08451$</field>
         <description>FortiGate unit blocked a file because it contains a virus (MIME)</description>
         <group>fortios.event.virus,fortios.category.mimefragmented,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101203" level="4">
-        <!-- MESGID_BLOCK_COMMAND -->
+    <rule id="101203" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08452$</field>
         <description>FortiGate unit blocked a virus command</description>
         <group>fortios.event.virus,fortios.category.command-blocked,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101204" level="4">
-        <!-- MESGID_OVERSIZE_WARNING -->
+    <rule id="101204" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08704$</field>
         <description>Defined file size limit was exceeded</description>
         <group>fortios.event.virus,fortios.category.oversize,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101205" level="4">
-        <!-- MESGID_OVERSIZE_NOTIF -->
+    <rule id="101205" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08705$</field>
         <description>File size limit was exceeded</description>
         <group>fortios.event.virus,fortios.category.oversize,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101206" level="4">
-        <!-- MESGID_OVERSIZE_STREAM_UNCOMP_WARNING -->
+    <rule id="101206" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08708$</field>
         <description>Stream-based uncompression reached size limit.</description>
         <group>fortios.event.virus,fortios.category.oversize,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101207" level="4">
-        <!-- MESGID_OVERSIZE_STREAM_UNCOMP_NOTIF -->
+    <rule id="101207" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08709$</field>
         <description>Stream-based uncompression reached size limit.</description>
         <group>fortios.event.virus,fortios.category.oversize,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101208" level="4">
-        <!-- MESGID_SWITCH_PROTO_WARNING -->
+    <rule id="101208" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08720$</field>
         <description>Switching protocols request (warning)</description>
         <group>fortios.event.virus,fortios.category.switchproto,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101209" level="4">
-        <!-- MESGID_SWITCH_PROTO_NOTIF -->
+    <rule id="101209" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08721$</field>
         <description>Switching protocols request (notice)</description>
         <group>fortios.event.virus,fortios.category.switchproto,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101210" level="4">
-        <!-- MESGID_SCAN_UNCOMPSIZELIMIT_WARNING -->
+    <rule id="101210" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08960$</field>
         <description>File reached the uncompressed nested limit</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101211" level="4">
-        <!-- MESGID_SCAN_UNCOMPSIZELIMIT_NOTIF -->
+    <rule id="101211" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08961$</field>
         <description>File reached the uncompressed size limit</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101212" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_ENCRYPTED_WARNING -->
+    <rule id="101212" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08962$</field>
         <description>Archived file is corrupted</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101213" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_ENCRYPTED_NOTIF -->
+    <rule id="101213" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08963$</field>
         <description>Archived file is encrypted</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101214" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_CORRUPTED_WARNING -->
+    <rule id="101214" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08964$</field>
         <description>Corrupted archive (warning)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101215" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_CORRUPTED_NOTIF -->
+    <rule id="101215" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08965$</field>
         <description>Corrupted archive (notice)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101216" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_MULTIPART_WARNING -->
+    <rule id="101216" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08966$</field>
         <description>File is a multipart archive or contains multiple files within the archive</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101217" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_MULTIPART_NOTIF -->
+    <rule id="101217" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08967$</field>
         <description>File is a multipart archive or contains multiple files within the archive</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101218" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_NESTED_WARNING -->
+    <rule id="101218" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08968$</field>
         <description>File is a nested archived file</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101219" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_NESTED_NOTIF -->
+    <rule id="101219" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08969$</field>
         <description>File is an archived type unhandled</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101220" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_OVERSIZE_WARNING -->
+    <rule id="101220" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08970$</field>
         <description>Archived file is oversized</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101221" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_OVERSIZE_NOTIF -->
+    <rule id="101221" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08971$</field>
         <description>Archived file is oversized</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101222" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_UNHANDLED_WARNING -->
+    <rule id="101222" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08972$</field>
         <description>Unhandled archive (warning)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101223" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_UNHANDLED_NOTIF -->
+    <rule id="101223" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08973$</field>
         <description>Unhandled archive (notice)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101224" level="4">
-        <!-- MESGID_SCAN_AV_ENGINE_LOAD_FAILED_ERROR -->
+    <rule id="101224" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08974$</field>
         <description>AV Engine load failed</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.error</group>
     </rule>
 
-    <rule id="101225" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_PARTIALLYCORRUPTED_WARNING -->
+    <rule id="101225" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08975$</field>
         <description>Partially corrupted archive (warning)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101226" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_PARTIALLYCORRUPTED_NOTIF -->
+    <rule id="101226" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08976$</field>
         <description>Partially corrupted archive (notice)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101227" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_TIMEOUT_WARNING -->
+    <rule id="101227" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08979$</field>
         <description>Archive scan timeout (warning)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101228" level="4">
-        <!-- MESGID_SCAN_ARCHIVE_TIMEOUT_NOTIF -->
+    <rule id="101228" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08980$</field>
         <description>Archive scan timeout (notice)</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101229" level="4">
-        <!-- MESGID_SCAN_AV_CDR_INTERNAL_ERROR -->
+    <rule id="101229" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08981$</field>
         <description>AV CDR engine internal error</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.error</group>
     </rule>
 
-    <rule id="101230" level="4">
-        <!-- MESGID_ANALYTICS_SUBMITTED -->
+    <rule id="101230" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09233$</field>
         <description>File submitted to Sandbox</description>
         <group>fortios.event.virus,fortios.category.analytics,fortios.severity.information</group>
     </rule>
 
-    <rule id="101231" level="4">
-        <!-- MESGID_ANALYTICS_INFECT_WARNING -->
+    <rule id="101231" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09234$</field>
         <description>File reported infected by FortiSandbox (warning)</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101232" level="4">
-        <!-- MESGID_ANALYTICS_INFECT_NOTIF -->
+    <rule id="101232" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09235$</field>
         <description>File reported infected by FortiSandbox (notice)</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101233" level="4">
-        <!-- MESGID_ANALYTICS_INFECT_MIME_WARNING -->
+    <rule id="101233" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09236$</field>
         <description>File reported infected by FortiSandbox (warning)</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101234" level="4">
-        <!-- MESGID_ANALYTICS_INFECT_MIME_NOTIF -->
+    <rule id="101234" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09237$</field>
         <description>File reported infected by FortiSandbox (notice)</description>
         <group>fortios.event.virus,fortios.category.infected,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101235" level="4">
-        <!-- MESGID_ANALYTICS_FSA_RESULT -->
+    <rule id="101235" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09238$</field>
         <description>File verdict returned from FortiSandbox</description>
         <group>fortios.event.virus,fortios.category.analytics,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101236" level="4">
-        <!-- MESGID_CONTENT_DISARM_NOTIF -->
+    <rule id="101236" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09239$</field>
         <description>Active content detected by Content Disarm engine</description>
         <group>fortios.event.virus,fortios.category.content-disarm,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101237" level="4">
-        <!-- MESGID_CONTENT_DISARM_WARNING -->
+    <rule id="101237" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">09240$</field>
         <description>File was disarmed by Content Disarm engine</description>
         <group>fortios.event.virus,fortios.category.content-disarm,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101238" level="4">
-        <!-- LOGID_EVENT_VOIP_SIP -->
+    <rule id="101238" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044032$</field>
         <description>VoIP SIP</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.information</group>
     </rule>
 
-    <rule id="101239" level="4">
-        <!-- LOGID_EVENT_VOIP_SIP_BLOCK -->
+    <rule id="101239" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044033$</field>
         <description>VoIP SIP blocked</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101240" level="4">
-        <!-- LOGID_EVENT_VOIP_SIP_FUZZING -->
+    <rule id="101240" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044034$</field>
         <description>VoIP SIP fuzzing</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.information</group>
     </rule>
 
-    <rule id="101241" level="4">
-        <!-- LOGID_EVENT_VOIP_SCCP_REGISTER -->
+    <rule id="101241" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044035$</field>
         <description>VoIP SCCP registered</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.information</group>
     </rule>
 
-    <rule id="101242" level="4">
-        <!-- LOGID_EVENT_VOIP_SCCP_UNREGISTER -->
+    <rule id="101242" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044036$</field>
         <description>VoIP SCCP unregistered</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.information</group>
     </rule>
 
-    <rule id="101243" level="4">
-        <!-- LOGID_EVENT_VOIP_SCCP_CALL_BLOCK -->
+    <rule id="101243" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044037$</field>
         <description>VoIP SCCP call blocked</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.information</group>
     </rule>
 
-    <rule id="101244" level="4">
-        <!-- LOGID_EVENT_VOIP_SCCP_CALL_INFO -->
+    <rule id="101244" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">044038$</field>
         <description>VoIP SCCP call information</description>
         <group>fortios.event.voip,fortios.category.voip,fortios.severity.information</group>
     </rule>
 
-    <rule id="101245" level="4">
-        <!-- LOGID_WAF_SIGNATURE_BLOCK -->
+    <rule id="101245" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030248$</field>
         <description>Web application firewall blocked application by signature</description>
         <group>fortios.event.waf,fortios.category.waf-signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101246" level="4">
-        <!-- LOGID_WAF_SIGNATURE_PASS -->
+    <rule id="101246" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030249$</field>
         <description>Web application firewall passed application by signature</description>
         <group>fortios.event.waf,fortios.category.waf-signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101247" level="4">
-        <!-- LOGID_WAF_SIGNATURE_ERASE -->
+    <rule id="101247" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030250$</field>
         <description>Web application firewall erased application by signature</description>
         <group>fortios.event.waf,fortios.category.waf-signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101248" level="4">
-        <!-- LOGID_WAF_CUSTOM_SIGNATURE_BLOCK -->
+    <rule id="101248" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030251$</field>
         <description>Web application firewall blocked application by custom signature</description>
         <group>fortios.event.waf,fortios.category.waf-custom-signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101249" level="4">
-        <!-- LOGID_WAF_CUSTOM_SIGNATURE_PASS -->
+    <rule id="101249" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030252$</field>
         <description>Web application firewall allowed application by custom signature</description>
         <group>fortios.event.waf,fortios.category.waf-custom-signature,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101250" level="4">
-        <!-- LOGID_WAF_METHOD_BLOCK -->
+    <rule id="101250" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030253$</field>
         <description>Web application firewall blocked application by HTTP method</description>
         <group>fortios.event.waf,fortios.category.waf-http-method,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101251" level="4">
-        <!-- LOGID_WAF_ADDRESS_LIST_BLOCK -->
+    <rule id="101251" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030255$</field>
         <description>Web application firewall blocked application by address list</description>
         <group>fortios.event.waf,fortios.category.waf-address-list,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101252" level="4">
-        <!-- LOGID_WAF_CONSTRAINTS_BLOCK -->
+    <rule id="101252" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030257$</field>
         <description>Web application firewall blocked application by HTTP constraints</description>
         <group>fortios.event.waf,fortios.category.waf-http-constraint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101253" level="4">
-        <!-- LOGID_WAF_CONSTRAINTS_PASS -->
+    <rule id="101253" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030258$</field>
         <description>Web application firewall allowed application by HTTP constraints</description>
         <group>fortios.event.waf,fortios.category.waf-http-constraint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101254" level="4">
-        <!-- LOGID_WAF_URL_ACCESS_PERMIT -->
+    <rule id="101254" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030259$</field>
         <description>Web application firewall allowed application by URL access permit</description>
         <group>fortios.event.waf,fortios.category.waf-url-access,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101255" level="4">
-        <!-- LOGID_WAF_URL_ACCESS_BYPASS -->
+    <rule id="101255" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030260$</field>
         <description>Web application firewall allowed application by URL access bypass</description>
         <group>fortios.event.waf,fortios.category.waf-url-access,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101256" level="4">
-        <!-- LOGID_WAF_URL_ACCESS_BLOCK -->
+    <rule id="101256" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">030261$</field>
         <description>Web application firewall blocked application by URL access</description>
         <group>fortios.event.waf,fortios.category.waf-url-access,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101257" level="4">
-        <!-- LOG_ID_WEB_CONTENT_BANWORD -->
+    <rule id="101257" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012288$</field>
         <description>Web content banned word found</description>
         <group>fortios.event.webfilter,fortios.category.content,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101258" level="4">
-        <!-- LOG_ID_WEB_CONTENT_EXEMPTWORD -->
+    <rule id="101258" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012290$</field>
         <description>Web content exempt word found</description>
         <group>fortios.event.webfilter,fortios.category.content,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101259" level="4">
-        <!-- LOG_ID_WEB_CONTENT_KEYWORD -->
+    <rule id="101259" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012292$</field>
         <description>Message contained a key word in the profile list</description>
         <group>fortios.event.webfilter,fortios.category.content,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101260" level="4">
-        <!-- LOG_ID_WEB_CONTENT_SEARCH -->
+    <rule id="101260" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012293$</field>
         <description>Search phrase detected</description>
         <group>fortios.event.webfilter,fortios.category.content,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101261" level="4">
-        <!-- LOG_ID_URL_FILTER_BLOCK -->
+    <rule id="101261" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012544$</field>
         <description>URL address was blocked because it was found in the URL filter list</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101262" level="4">
-        <!-- LOG_ID_URL_FILTER_EXEMPT -->
+    <rule id="101262" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012545$</field>
         <description>URL address was exempted because it was found in the URL filter list</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101263" level="4">
-        <!-- LOG_ID_URL_FILTER_ALLOW -->
+    <rule id="101263" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012546$</field>
         <description>URL address was allowed because it was found in the URL filter list</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101264" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_HOSTNAME_HTTP_BLK -->
+    <rule id="101264" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012547$</field>
         <description>The request contained an invalid domain name</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101265" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_HOSTNAME_HTTPS_BLK -->
+    <rule id="101265" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012548$</field>
         <description>HTTP certificate request contained an invalid domain name</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101266" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_HOSTNAME_HTTP_PASS -->
+    <rule id="101266" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012549$</field>
         <description>HTTP request contained an invalid name so the session has been filtered by IP only</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101267" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_HOSTNAME_HTTPS_PASS -->
+    <rule id="101267" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012550$</field>
         <description>HTTPS request contained an invalid name so the session has been filtered by IP only</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101268" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_HOSTNAME_SNI_BLK -->
+    <rule id="101268" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012551$</field>
         <description>Insufficient resources</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101269" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_HOSTNAME_SNI_PASS -->
+    <rule id="101269" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012552$</field>
         <description>Getting the host name failed</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101270" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_CERT -->
+    <rule id="101270" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012553$</field>
         <description>Server certificate validation failed</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101271" level="4">
-        <!-- LOG_ID_URL_FILTER_INVALID_SESSION -->
+    <rule id="101271" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012554$</field>
         <description>SSL session blocked because its identification number was unknown</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101272" level="4">
-        <!-- LOG_ID_URL_FILTER_SRV_CERT_ERR_BLK -->
+    <rule id="101272" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012555$</field>
         <description>SSL session blocked</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101273" level="4">
-        <!-- LOG_ID_URL_FILTER_SRV_CERT_ERR_PASS -->
+    <rule id="101273" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012556$</field>
         <description>SSL session ignored</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101274" level="4">
-        <!-- LOG_ID_URL_FILTER_FAMS_NOT_ACTIVE -->
+    <rule id="101274" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012557$</field>
         <description>The FortiGuard Analysis and Management Service is not active. You must enable this service</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101275" level="4">
-        <!-- LOG_ID_URL_FILTER_RATING_ERR -->
+    <rule id="101275" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012558$</field>
         <description>Rating error occurred</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101276" level="4">
-        <!-- LOG_ID_URL_FILTER_PASS -->
+    <rule id="101276" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012559$</field>
         <description>URL passed because it was in the URL filter list</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101277" level="4">
-        <!-- LOG_ID_URL_WISP_BLOCK -->
+    <rule id="101277" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012560$</field>
         <description>URL blocked by Websense service</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101278" level="4">
-        <!-- LOG_ID_URL_WISP_REDIR -->
+    <rule id="101278" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012561$</field>
         <description>URL blocked with redirect message by Websense service</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101279" level="4">
-        <!-- LOG_ID_URL_WISP_ALLOW -->
+    <rule id="101279" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012562$</field>
         <description>URL allowed by Websense service</description>
         <group>fortios.event.webfilter,fortios.category.urlfilter,fortios.severity.information</group>
     </rule>
 
-    <rule id="101280" level="4">
-        <!-- LOG_ID_WEB_SSL_EXEMPT -->
+    <rule id="101280" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012688$</field>
         <description>URL address was exempted because it was found in the ssl-exempt</description>
         <group>fortios.event.webfilter,fortios.category.ssl-exempt,fortios.severity.information</group>
     </rule>
 
-    <rule id="101281" level="4">
-        <!-- LOG_ID_WEB_FTGD_ERR -->
+    <rule id="101281" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012800$</field>
         <description>Rating error occurred (error)</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_err,fortios.severity.error</group>
     </rule>
 
-    <rule id="101282" level="4">
-        <!-- LOG_ID_WEB_FTGD_WARNING -->
+    <rule id="101282" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012801$</field>
         <description>Rating error occurred (warning)</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_err,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101283" level="4">
-        <!-- LOG_ID_WEB_FTGD_QUOTA -->
+    <rule id="101283" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">012802$</field>
         <description>Daily FortiGuard quota status</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_quota,fortios.severity.information</group>
     </rule>
 
-    <rule id="101284" level="4">
-        <!-- LOG_ID_WEB_FTGD_CAT_BLK -->
+    <rule id="101284" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013056$</field>
         <description>URL belongs to an blocked category within the firewall policy</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_blk,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101285" level="4">
-        <!-- LOG_ID_WEB_FTGD_CAT_WARN -->
+    <rule id="101285" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013057$</field>
         <description>URL belongs to a category with warnings enabled</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_blk,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101286" level="4">
-        <!-- LOG_ID_WEB_FTGD_CAT_ALLOW -->
+    <rule id="101286" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013312$</field>
         <description>URL belongs to an allowed category within the firewall policy</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_allow,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101287" level="4">
-        <!-- LOG_ID_WEB_FTGD_QUOTA_COUNTING -->
+    <rule id="101287" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013315$</field>
         <description>FortiGuard web filter category quota counting log message</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_quota_counting,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101288" level="4">
-        <!-- LOG_ID_WEB_FTGD_QUOTA_EXPIRED -->
+    <rule id="101288" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013316$</field>
         <description>FortiGuard web filter category quota expired log message</description>
         <group>fortios.event.webfilter,fortios.category.ftgd_quota_expired,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101289" level="4">
-        <!-- LOG_ID_WEB_URL -->
+    <rule id="101289" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013317$</field>
         <description>URL has been visited</description>
         <group>fortios.event.webfilter,fortios.category.urlmonitor,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101290" level="4">
-        <!-- LOG_ID_WEB_SCRIPTFILTER_ACTIVEX -->
+    <rule id="101290" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013568$</field>
         <description>ActiveX script removed</description>
         <group>fortios.event.webfilter,fortios.category.activexfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101291" level="4">
-        <!-- LOG_ID_WEB_SCRIPTFILTER_COOKIE -->
+    <rule id="101291" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013573$</field>
         <description>Cookie removed</description>
         <group>fortios.event.webfilter,fortios.category.cookiefilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101292" level="4">
-        <!-- LOG_ID_WEB_SCRIPTFILTER_APPLET -->
+    <rule id="101292" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013584$</field>
         <description>Java applet removed</description>
         <group>fortios.event.webfilter,fortios.category.appletfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101293" level="4">
-        <!-- LOG_ID_WEB_SCRIPTFILTER_OTHER -->
+    <rule id="101293" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013600$</field>
         <description>Script entity removed</description>
         <group>fortios.event.webfilter,fortios.category.scriptfilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101294" level="4">
-        <!-- LOG_ID_WEB_WF_COOKIE -->
+    <rule id="101294" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013601$</field>
         <description>Cookie removed entirely</description>
         <group>fortios.event.webfilter,fortios.category.cookiefilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101295" level="4">
-        <!-- LOG_ID_WEB_WF_REFERER -->
+    <rule id="101295" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013602$</field>
         <description>Referrer removed from request</description>
         <group>fortios.event.webfilter,fortios.category.cookiefilter,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101296" level="4">
-        <!-- LOG_ID_WEB_WF_COMMAND_BLOCK -->
+    <rule id="101296" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013603$</field>
         <description>Command blocked</description>
         <group>fortios.event.webfilter,fortios.category.webfilter_command_block,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101297" level="4">
-        <!-- LOG_ID_CONTENT_TYPE_BLOCK -->
+    <rule id="101297" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013616$</field>
         <description>Blocked by HTTP header content type</description>
         <group>fortios.event.webfilter,fortios.category.content,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101298" level="4">
-        <!-- LOGID_HTTP_HDR_CHG_REQ -->
+    <rule id="101298" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013632$</field>
         <description>Depends on info in msg field</description>
         <group>fortios.event.webfilter,fortios.category.http_header_change,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101299" level="4">
-        <!-- LOGID_HTTP_HDR_CHG_RESP -->
+    <rule id="101299" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013633$</field>
         <description>Depends on info in msg field</description>
         <group>fortios.event.webfilter,fortios.category.http_header_change,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101300" level="4">
-        <!-- LOG_ID_WEB_WF_ANTIPHISH_MATCH_URL_ALLOW -->
+    <rule id="101300" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013648$</field>
         <description>Antiphishing matched a URL filter rule without blocking the request.</description>
         <group>fortios.event.webfilter,fortios.category.antiphishing,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101301" level="4">
-        <!-- LOG_ID_WEB_WF_ANTIPHISH_MATCH_FTGD_ALLOW -->
+    <rule id="101301" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013649$</field>
         <description>Antiphishing matched a Fortiguard category rule without blocking the request.</description>
         <group>fortios.event.webfilter,fortios.category.antiphishing,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101302" level="4">
-        <!-- LOG_ID_WEB_WF_ANTIPHISH_MATCH_DEFAULT_ALLOW -->
+    <rule id="101302" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013650$</field>
         <description>Antiphishing reached default action without blocking the request.</description>
         <group>fortios.event.webfilter,fortios.category.antiphishing,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101303" level="4">
-        <!-- LOG_ID_WEB_WF_ANTIPHISH_MATCH_URL_BLOCK -->
+    <rule id="101303" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013651$</field>
         <description>Antiphishing matched a URL filter rule and blocked the request.</description>
         <group>fortios.event.webfilter,fortios.category.antiphishing,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101304" level="4">
-        <!-- LOG_ID_WEB_WF_ANTIPHISH_MATCH_FTGD_BLOCK -->
+    <rule id="101304" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013652$</field>
         <description>Antiphishing matched a Fortiguard category rule and blocked the request.</description>
         <group>fortios.event.webfilter,fortios.category.antiphishing,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101305" level="4">
-        <!-- LOG_ID_WEB_WF_ANTIPHISH_MATCH_DEFAULT_BLOCK -->
+    <rule id="101305" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013653$</field>
         <description>Antiphishing reached default action and blocked the request.</description>
         <group>fortios.event.webfilter,fortios.category.antiphishing,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101306" level="4">
-        <!-- LOG_ID_VIDEOFILTER_CATEGORY_BLOCK -->
+    <rule id="101306" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013664$</field>
         <description>Video category is blocked.</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-category,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101307" level="4">
-        <!-- LOG_ID_VIDEOFILTER_CATEGORY_MONITOR -->
+    <rule id="101307" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013665$</field>
         <description>Video category is monitored</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-category,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101308" level="4">
-        <!-- LOG_ID_VIDEOFILTER_CATEGORY_ALLOW -->
+    <rule id="101308" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013666$</field>
         <description>Video category is allowed</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-category,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101309" level="4">
-        <!-- LOG_ID_VIDEOFILTER_CHANNEL_BLOCK -->
+    <rule id="101309" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013680$</field>
         <description>Video channel is blocked.</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-channel,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101310" level="4">
-        <!-- LOG_ID_VIDEOFILTER_CHANNEL_MONITOR -->
+    <rule id="101310" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013681$</field>
         <description>Video channel is monitored</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-channel,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101311" level="4">
-        <!-- LOG_ID_VIDEOFILTER_CHANNEL_ALLOW -->
+    <rule id="101311" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013682$</field>
         <description>Video channel is allowed</description>
@@ -10422,7 +10422,7 @@
     </rule>
 
     <rule id="101312" level="4">
-        <!-- LOG_ID_UNKNOWN_CE_BLOCK -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">013696$</field>
         <description>Unknown content-encoding detected and blocked.</description>
@@ -10430,463 +10430,463 @@
     </rule>
 
     <rule id="101313" level="4">
-        <!-- LOG_ID_UNKNOWN_CE_BYPASS -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">013697$</field>
         <description>Scan is bypassed due to unknown content-encoding.</description>
         <group>fortios.event.webfilter,fortios.category.unknown-ce,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101314" level="4">
-        <!-- LOG_ID_ENTER_EXTREME_LOW_MEM_MODE -->
+    <rule id="101314" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022022$</field>
         <description>Extreme low memory mode entered</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101315" level="4">
-        <!-- LOG_ID_LEAVE_EXTREME_LOW_MEM_MODE -->
+    <rule id="101315" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022023$</field>
         <description>Extreme low memory mode exited</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101316" level="4">
-        <!-- LOG_ID_CASB_ACCESS_BLOCKED -->
+    <rule id="101316" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">010000$</field>
         <description>Web content banned activity found</description>
         <group>fortios.event.casb,fortios.category.casb,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101317" level="4">
-        <!-- LOG_ID_CASB_ACCESS_BYPASS -->
+    <rule id="101317" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">010001$</field>
         <description>Web content activity found</description>
         <group>fortios.event.casb,fortios.category.casb,fortios.severity.information</group>
     </rule>
 
-    <rule id="101318" level="4">
-        <!-- LOG_ID_CASB_ACCESS_MONITOR -->
+    <rule id="101318" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">010002$</field>
         <description>Web content activity found</description>
         <group>fortios.event.casb,fortios.category.casb,fortios.severity.information</group>
     </rule>
 
-    <rule id="101319" level="4">
-        <!-- LOG_ID_DLP_LIC_EXPIRE -->
+    <rule id="101319" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020136$</field>
         <description>FortiGuard Data leak server prevention license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101320" level="4">
-        <!-- LOG_ID_FGSA_LIC_EXPIRE -->
+    <rule id="101320" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020137$</field>
         <description>Attack Surface Security Rating Service license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101321" level="4">
-        <!-- LOG_ID_SWOS_LIC_EXPIRE -->
+    <rule id="101321" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020138$</field>
         <description>FortiGuard SD-WAN Overlay as a Service license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101322" level="4">
-        <!-- LOG_ID_FGCS_ACC_LIC_EXPIRE -->
+    <rule id="101322" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020139$</field>
         <description>FortiGSLB Cloud Account Level license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101323" level="4">
-        <!-- LOG_ID_FSPA_LIC_EXPIRE -->
+    <rule id="101323" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020140$</field>
         <description>FortiSASE Secure Private Access license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101324" level="4">
-        <!-- LOG_ID_FSFG_LIC_EXPIRE -->
+    <rule id="101324" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020141$</field>
         <description>FortiSASE LAN Extension license expiring</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101325" level="4">
-        <!-- LOG_ID_DEV_VUNL_FTGD_LOOKUP -->
+    <rule id="101325" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">020150$</field>
         <description>Device vulnerability lookup on FortiGuard</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101326" level="4">
-        <!-- LOG_ID_SCANUNIT_DLP_SIGNATURE_REMOVE -->
+    <rule id="101326" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022817$</field>
         <description>Scanunit DLP signature update error</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101327" level="4">
-        <!-- LOG_ID_FLTUND_NEW_CONN -->
+    <rule id="101327" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022874$</field>
         <description>Switch-controller FortilinkLite new connection</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101328" level="4">
-        <!-- LOG_ID_FLTUND_CONN_DOWN -->
+    <rule id="101328" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022875$</field>
         <description>Switch-controller FortilinkLite connection down</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101329" level="4">
-        <!-- LOG_ID_FLTUND_RCV_BOOTSTRAP -->
+    <rule id="101329" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022876$</field>
         <description>Switch-controller FortilinkLite received bootstrap</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.information</group>
     </rule>
 
-    <rule id="101330" level="4">
-        <!-- LOG_ID_FLTUND_CONN_ONLINE -->
+    <rule id="101330" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022877$</field>
         <description>Switch-controller FortilinkLite tunnel online</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101331" level="4">
-        <!-- LOG_ID_FLTUND_CONN_OFFLINE -->
+    <rule id="101331" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022878$</field>
         <description>Switch-controller FortilinkLite tunnel offline</description>
         <group>fortios.event.event,fortios.category.switch-controller,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101332" level="4">
-        <!-- LOG_ID_EVENT_VWL_APP_PERF_METRICS -->
+    <rule id="101332" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022937$</field>
         <description>SDWAN application performance metrics via FortiMonitor</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.information</group>
     </rule>
 
-    <rule id="101333" level="4">
-        <!-- LOG_ID_EVENT_VWL_WAN_SPEEDTEST_RESULT -->
+    <rule id="101333" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022938$</field>
         <description>SD-WAN Bandwidth monitoring result</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.information</group>
     </rule>
 
-    <rule id="101334" level="4">
-        <!-- LOG_ID_EVENT_VWL_FAIL_DETECT -->
+    <rule id="101334" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022939$</field>
         <description>SD-WAN fail detect</description>
         <group>fortios.event.event,fortios.category.sdwan,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101335" level="4">
-        <!-- LOG_ID_EVENT_LINK_MONITOR_FAIL_DETECT -->
+    <rule id="101335" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">022940$</field>
         <description>Link monitor fail detect</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101336" level="4">
-        <!-- LOG_ID_CC_KAT_SUCCESS -->
+    <rule id="101336" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">032055$</field>
         <description>KAT tests succeeded</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101337" level="4">
-        <!-- LOG_ID_NP6XLITE_HPE_PACKET_DROP -->
+    <rule id="101337" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034420$</field>
         <description>NP6XLITE HPE is dropping packets</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101338" level="4">
-        <!-- LOG_ID_NP6XLITE_HPE_PACKET_FLOOD -->
+    <rule id="101338" level="10">
+        
         <if_sid>100010</if_sid>
         <field name="logid">034421$</field>
         <description>NP6XLITE HPE under a packets flood</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.critical</group>
     </rule>
 
-    <rule id="101339" level="4">
-        <!-- LOG_ID_PCP_MAPPING_CREATE -->
+    <rule id="101339" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035051$</field>
         <description>Create PCP mapping</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101340" level="4">
-        <!-- LOG_ID_PCP_MAPPING_DELETE -->
+    <rule id="101340" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035052$</field>
         <description>Delete PCP mapping</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101341" level="4">
-        <!-- LOG_ID_PCP_MAPPING_RENEW -->
+    <rule id="101341" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">035053$</field>
         <description>Renew PCP mapping</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101342" level="4">
-        <!-- LOGID_EVENT_ICAP_REMOTE_SRV_STAT -->
+    <rule id="101342" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">040961$</field>
         <description>Icap remote server stat</description>
         <group>fortios.event.event,fortios.category.webproxy,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101343" level="4">
-        <!-- LOG_ID_EC_REG_SUCCEED -->
+    <rule id="101343" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045101$</field>
         <description>FortiClient registered</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101344" level="4">
-        <!-- LOG_ID_EC_EMS_UPGRADE_FAIL -->
+    <rule id="101344" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045132$</field>
         <description>EMS entry could not be upgraded</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.error</group>
     </rule>
 
-    <rule id="101345" level="4">
-        <!-- LOG_ID_EC_SHM_MISSING_QUERY -->
+    <rule id="101345" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">045133$</field>
         <description>FCEMS shared memory missing query statistics</description>
         <group>fortios.event.event,fortios.category.endpoint,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101346" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_SIM_SWITCH -->
+    <rule id="101346" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046518$</field>
         <description>LTE modem active SIM card switch event</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101347" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_SIM_SWITCH_CONNECTION_STATE -->
+    <rule id="101347" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046519$</field>
         <description>LTE modem active SIM card switched: modem disconnection detected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101348" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_SIM_SWITCH_LINK_MONITOR -->
+    <rule id="101348" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046520$</field>
         <description>LTE modem active SIM card switched: link monitor probe failure detected</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101349" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_SIM_FLIP -->
+    <rule id="101349" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046521$</field>
         <description>LTE modem active SIM card slot flipped back and forth in short time</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101350" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLING_DATA_ALERT -->
+    <rule id="101350" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046522$</field>
         <description>LTE billing data usage reached configured threshold</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101351" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLING_TIME_REFRESH -->
+    <rule id="101351" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046523$</field>
         <description>LTE billing time passed, refresh billing date counter</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101352" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_SIM_SWITCH_DATA_PLAN -->
+    <rule id="101352" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046524$</field>
         <description>LTE modem active SIM card switched: data plan reached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101353" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLING_STOP_NETWORK -->
+    <rule id="101353" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046525$</field>
         <description>LTE modem stop network due to data plan reached</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101354" level="4">
-        <!-- LOG_ID_INTERNAL_LTE_MODEM_BILLING_DATA_PLAN_OVER -->
+    <rule id="101354" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">046526$</field>
         <description>LTE billing data usage reached data limit</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.information</group>
     </rule>
 
-    <rule id="101355" level="4">
-        <!-- LOG_ID_FORTICONVERTER_RESULT_READY -->
+    <rule id="101355" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053320$</field>
         <description>FortiConverter ticket has a result file ready</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101356" level="4">
-        <!-- LOG_ID_FORTICONVERTER_CONFIG_UPLOADED -->
+    <rule id="101356" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">053321$</field>
         <description>Uploaded local config to a FortiConverter ticket</description>
         <group>fortios.event.event,fortios.category.system,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101357" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_HANDSHAKE_FAILURE -->
+    <rule id="101357" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062308$</field>
         <description>Error occured during SSL handshake.</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.information</group>
     </rule>
 
-    <rule id="101358" level="4">
-        <!-- LOG_ID_SSL_ANOMALY_CERT_INVALID -->
+    <rule id="101358" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">062309$</field>
         <description>Server certificate has security problem</description>
         <group>fortios.event.ssl,fortios.category.ssl-anomaly,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101359" level="4">
-        <!-- LOG_ID_OT_VPATCH_BLOCK -->
+    <rule id="101359" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">064600$</field>
         <description>Traffic was blocked by OT virtual patch</description>
         <group>fortios.event.virtual-patch,fortios.category.ot-vpatch,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101360" level="4">
-        <!-- LOG_ID_OT_VPATCH_LOG -->
+    <rule id="101360" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">064601$</field>
         <description>Traffic was detected by OT virtual patch</description>
         <group>fortios.event.virtual-patch,fortios.category.ot-vpatch,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101361" level="4">
-        <!-- LOG_ID_LOCALIN_VPATCH_BLOCK -->
+    <rule id="101361" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">064610$</field>
         <description>Traffic was blocked by local-in virtual patch</description>
         <group>fortios.event.virtual-patch,fortios.category.localin-vpatch,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101362" level="4">
-        <!-- LOG_ID_LOCALIN_VPATCH_LOG -->
+    <rule id="101362" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">064611$</field>
         <description>Traffic was detected by local-in virtual patch</description>
         <group>fortios.event.virtual-patch,fortios.category.localin-vpatch,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101363" level="4">
-        <!-- MESGID_SCAN_AV_MAX_MEMORY_REACHED_ERROR -->
+    <rule id="101363" level="8">
+        
         <if_sid>100010</if_sid>
         <field name="logid">08982$</field>
         <description>Exceeded max AV memory</description>
         <group>fortios.event.virus,fortios.category.scanerror,fortios.severity.error</group>
     </rule>
 
-    <rule id="101364" level="4">
-        <!-- LOG_ID_CONTENT_TYPE_EXEMPT -->
+    <rule id="101364" level="2">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013617$</field>
         <description>Exempted by HTTP header content type</description>
         <group>fortios.event.webfilter,fortios.category.content,fortios.severity.information</group>
     </rule>
 
-    <rule id="101365" level="4">
-        <!-- LOG_ID_VIDEOFILTER_TITLE_BLOCK -->
+    <rule id="101365" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013712$</field>
         <description>Video title is blocked.</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-title,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101366" level="4">
-        <!-- LOG_ID_VIDEOFILTER_TITLE_MONITOR -->
+    <rule id="101366" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013713$</field>
         <description>Video title is monitored</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-title,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101367" level="4">
-        <!-- LOG_ID_VIDEOFILTER_TITLE_ALLOW -->
+    <rule id="101367" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013714$</field>
         <description>Video title is allowed</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-title,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101368" level="4">
-        <!-- LOG_ID_VIDEOFILTER_DESCRIPTION_BLOCK -->
+    <rule id="101368" level="6">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013728$</field>
         <description>Video description is blocked.</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-description,fortios.severity.warning</group>
     </rule>
 
-    <rule id="101369" level="4">
-        <!-- LOG_ID_VIDEOFILTER_DESCRIPTION_MONITOR -->
+    <rule id="101369" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013729$</field>
         <description>Video description is monitored</description>
         <group>fortios.event.webfilter,fortios.category.videofilter-description,fortios.severity.notice</group>
     </rule>
 
-    <rule id="101370" level="4">
-        <!-- LOG_ID_VIDEOFILTER_DESCRIPTION_ALLOW -->
+    <rule id="101370" level="3">
+        
         <if_sid>100010</if_sid>
         <field name="logid">013730$</field>
         <description>Video description is allowed</description>
@@ -10894,7 +10894,7 @@
     </rule>
 
     <rule id="101371" level="4">
-        <!-- LOG_ID_RAD_FAIL_IPV6_SOCKET -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020047$</field>
         <description>RADVD failed to create an IPv6 socket</description>
@@ -10902,7 +10902,7 @@
     </rule>
 
     <rule id="101372" level="4">
-        <!-- LOG_ID_RAD_FAIL_OPT_IPV6_PKTINFO -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020048$</field>
         <description>RADVD failed to set IPv6 packet info</description>
@@ -10910,7 +10910,7 @@
     </rule>
 
     <rule id="101373" level="4">
-        <!-- LOG_ID_RAD_FAIL_OPT_IPV6_CHECKSUM -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020049$</field>
         <description>RADVD failed to set IPv6 checksum</description>
@@ -10918,7 +10918,7 @@
     </rule>
 
     <rule id="101374" level="4">
-        <!-- LOG_ID_RAD_FAIL_OPT_IPV6_UNICAST_HOPS -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020050$</field>
         <description>RADVD failed to set IPv6 unicast hops</description>
@@ -10926,7 +10926,7 @@
     </rule>
 
     <rule id="101375" level="4">
-        <!-- LOG_ID_RAD_FAIL_OPT_IPV6_MULTICAST_HOPS -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020051$</field>
         <description>RADVD failed to set IPv6 multicast hops</description>
@@ -10934,7 +10934,7 @@
     </rule>
 
     <rule id="101376" level="4">
-        <!-- LOG_ID_RAD_FAIL_OPT_IPV6_HOPLIMIT -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020052$</field>
         <description>RADVD failed to set IPv6 hop limit</description>
@@ -10942,7 +10942,7 @@
     </rule>
 
     <rule id="101377" level="4">
-        <!-- LOG_ID_RAD_FAIL_OPT_IPPROTO_ICMPV6 -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020053$</field>
         <description>RADVD failed to set ICMPv6 filter</description>
@@ -10950,7 +10950,7 @@
     </rule>
 
     <rule id="101378" level="4">
-        <!-- LOG_ID_RAD_EXIT_BY_SIGNAL -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020054$</field>
         <description>RADVD exited due to received signal</description>
@@ -10958,7 +10958,7 @@
     </rule>
 
     <rule id="101379" level="4">
-        <!-- LOG_ID_RAD_FAIL_CMDB_QUERY -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020055$</field>
         <description>RADVD interface query creation failed</description>
@@ -10966,7 +10966,7 @@
     </rule>
 
     <rule id="101380" level="4">
-        <!-- LOG_ID_RAD_FAIL_CMDB_FOR_EACH -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020056$</field>
         <description>RADVD query error</description>
@@ -10974,7 +10974,7 @@
     </rule>
 
     <rule id="101381" level="4">
-        <!-- LOG_ID_RAD_FAIL_FIND_VIRT_INTF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020057$</field>
         <description>RADVD virtual interface not found</description>
@@ -10982,7 +10982,7 @@
     </rule>
 
     <rule id="101382" level="4">
-        <!-- LOG_ID_RAD_UNLOAD_INTF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">020058$</field>
         <description>RADVD unloaded interface</description>
@@ -10990,7 +10990,7 @@
     </rule>
 
     <rule id="101383" level="4">
-        <!-- LOG_ID_FDS_SRV_CHG -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">022914$</field>
         <description>FortiGate Cloud server changed</description>
@@ -10998,7 +10998,7 @@
     </rule>
 
     <rule id="101384" level="4">
-        <!-- LOG_ID_ADMIN_MTNER_LOGIN_SUCC -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">032053$</field>
         <description>Admin monitor login successful</description>
@@ -11006,7 +11006,7 @@
     </rule>
 
     <rule id="101385" level="4">
-        <!-- LOG_ID_ADMIN_MTNER_LOGOUT -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">032054$</field>
         <description>Admin monitor logout successful</description>
@@ -11014,7 +11014,7 @@
     </rule>
 
     <rule id="101386" level="4">
-        <!-- LOG_ID_RESTORE_IMG_USB -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">032199$</field>
         <description>Image restored from USB</description>
@@ -11022,7 +11022,7 @@
     </rule>
 
     <rule id="101387" level="4">
-        <!-- LOG_ID_RESTORE_CONF_BY_USB -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">032567$</field>
         <description>Configuration restored by USB</description>
@@ -11030,7 +11030,7 @@
     </rule>
 
     <rule id="101388" level="4">
-        <!-- LOG_ID_ADMIN_MTNER_LOGOUT_DISCONNECT -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">032570$</field>
         <description>Admin monitor disconnected</description>
@@ -11038,7 +11038,7 @@
     </rule>
 
     <rule id="101389" level="4">
-        <!-- LOGID_EVENT_CONFIG_OBJATTR_MTNER -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">044549$</field>
         <description>Object attribute configured by maintainer</description>
@@ -11046,7 +11046,7 @@
     </rule>
 
     <rule id="101390" level="4">
-        <!-- LOGID_EVENT_CONFIG_OBJ_MTNER -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">044550$</field>
         <description>Object configured by maintainer</description>
@@ -11054,7 +11054,7 @@
     </rule>
 
     <rule id="101391" level="4">
-        <!-- LOGID_EVENT_CONFIG_ATTR_MTNER -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">044551$</field>
         <description>Attribute configured by maintainer</description>
@@ -11062,7 +11062,7 @@
     </rule>
 
     <rule id="101392" level="4">
-        <!-- LOGID_EVENT_CONFIG_PATH_MTNER -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">044552$</field>
         <description>Path configured by maintainer</description>
@@ -11070,7 +11070,7 @@
     </rule>
 
     <rule id="101393" level="4">
-        <!-- MESGID_FORTIAI_FAILURE_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08983$</field>
         <description>FortiNDR submission failure (warning)</description>
@@ -11078,7 +11078,7 @@
     </rule>
 
     <rule id="101394" level="4">
-        <!-- MESGID_FORTIAI_FAILURE_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08984$</field>
         <description>FortiNDR submission failure (notice)</description>
@@ -11086,7 +11086,7 @@
     </rule>
 
     <rule id="101395" level="4">
-        <!-- MESGID_FORTIAI_TIMEOUT_WARNING -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08985$</field>
         <description>FortiNDR scan timeout (warning)</description>
@@ -11094,7 +11094,7 @@
     </rule>
 
     <rule id="101396" level="4">
-        <!-- MESGID_FORTIAI_TIMEOUT_NOTIF -->
+        
         <if_sid>100010</if_sid>
         <field name="logid">08986$</field>
         <description>FortiNDR scan timeout (notice)</description>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 data-start="409" data-end="432">Summary of Changes:</h3>
<p data-start="433" data-end="717">This pull request updates the <code data-start="463" data-end="489">0391-fortigate_rules.xml</code> file by assigning more accurate Wazuh rule levels based on the <strong data-start="553" data-end="587">original Fortinet log severity</strong> for each <code data-start="597" data-end="604">logid</code>.<br data-start="605" data-end="608">
Previously, all rules had the same alert level i.e., <code>level="4"</code>, which did not reflect the true risk profile of Fortinet logs.</p>
<hr data-start="719" data-end="722">
<h3 data-start="724" data-end="762">Fortinet → Wazuh Severity Mapping:</h3>
<p data-start="764" data-end="917">I reviewed Fortinet's official log reference documentation and mapped their log severities to appropriate Wazuh levels using the following general logic:</p>
<div class="_tableContainer_16hzy_1"><div tabindex="-1" class="_tableWrapper_16hzy_14 group flex w-fit flex-col-reverse">
<table>
  <thead>
    <tr>
      <th>Fortinet Severity</th>
      <th>Mapped Wazuh Level</th>
      <th>Notes</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>(0) Emergency</td>
      <td>15</td>
      <td>Highest severity — critical system failure</td>
    </tr>
    <tr>
      <td>(1) Alert</td>
      <td>14</td>
      <td>Security alerts requiring immediate action</td>
    </tr>
    <tr>
      <td>(2) Critical</td>
      <td>10</td>
      <td>Very high priority — immediate remediation</td>
    </tr>
    <tr>
      <td>(3) Error</td>
      <td>8</td>
      <td>Significant errors needing attention</td>
    </tr>
    <tr>
      <td>(4) Warning</td>
      <td>6</td>
      <td>Suspicious or risky behavior</td>
    </tr>
    <tr>
      <td>(5) Notification</td>
      <td>3</td>
      <td>Minor but notable system events</td>
    </tr>
    <tr>
      <td>(6) Information</td>
      <td>2</td>
      <td>Informational logs, general activity</td>
    </tr>
    <tr>
      <td>(7) Debug / Unknown</td>
      <td>4</td>
      <td>Default level when severity is not mapped</td>
    </tr>
  </tbody>
</table>

<div class="sticky end-(--thread-content-margin) h-0 self-end select-none"><div class="absolute end-0 flex items-end"><span class="" data-state="closed"><button class="bg-token-bg-primary hover:bg-token-bg-tertiary text-token-text-secondary my-1 rounded-sm p-1 transition-opacity group-[:not(:hover):not(:focus-within)]:pointer-events-none group-[:not(:hover):not(:focus-within)]:opacity-0"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="icon"><path d="M12.668 10.667C12.668 9.95614 12.668 9.46258 12.6367 9.0791C12.6137 8.79732 12.5758 8.60761 12.5244 8.46387L12.4688 8.33399C12.3148 8.03193 12.0803 7.77885 11.793 7.60254L11.666 7.53125C11.508 7.45087 11.2963 7.39395 10.9209 7.36328C10.5374 7.33197 10.0439 7.33203 9.33301 7.33203H6.5C5.78896 7.33203 5.29563 7.33195 4.91211 7.36328C4.63016 7.38632 4.44065 7.42413 4.29688 7.47559L4.16699 7.53125C3.86488 7.68518 3.61186 7.9196 3.43555 8.20703L3.36524 8.33399C3.28478 8.49198 3.22795 8.70352 3.19727 9.0791C3.16595 9.46259 3.16504 9.95611 3.16504 10.667V13.5C3.16504 14.211 3.16593 14.7044 3.19727 15.0879C3.22797 15.4636 3.28473 15.675 3.36524 15.833L3.43555 15.959C3.61186 16.2466 3.86474 16.4807 4.16699 16.6348L4.29688 16.6914C4.44063 16.7428 4.63025 16.7797 4.91211 16.8027C5.29563 16.8341 5.78896 16.835 6.5 16.835H9.33301C10.0439 16.835 10.5374 16.8341 10.9209 16.8027C11.2965 16.772 11.508 16.7152 11.666 16.6348L11.793 16.5645C12.0804 16.3881 12.3148 16.1351 12.4688 15.833L12.5244 15.7031C12.5759 15.5594 12.6137 15.3698 12.6367 15.0879C12.6681 14.7044 12.668 14.211 12.668 13.5V10.667ZM13.998 12.665C14.4528 12.6634 14.8011 12.6602 15.0879 12.6367C15.4635 12.606 15.675 12.5492 15.833 12.4688L15.959 12.3975C16.2466 12.2211 16.4808 11.9682 16.6348 11.666L16.6914 11.5361C16.7428 11.3924 16.7797 11.2026 16.8027 10.9209C16.8341 10.5374 16.835 10.0439 16.835 9.33301V6.5C16.835 5.78896 16.8341 5.29563 16.8027 4.91211C16.7797 4.63025 16.7428 4.44063 16.6914 4.29688L16.6348 4.16699C16.4807 3.86474 16.2466 3.61186 15.959 3.43555L15.833 3.36524C15.675 3.28473 15.4636 3.22797 15.0879 3.19727C14.7044 3.16593 14.211 3.16504 13.5 3.16504H10.667C9.9561 3.16504 9.46259 3.16595 9.0791 3.19727C8.79739 3.22028 8.6076 3.2572 8.46387 3.30859L8.33399 3.36524C8.03176 3.51923 7.77886 3.75343 7.60254 4.04102L7.53125 4.16699C7.4508 4.32498 7.39397 4.53655 7.36328 4.91211C7.33985 5.19893 7.33562 5.54719 7.33399 6.00195H9.33301C10.022 6.00195 10.5791 6.00131 11.0293 6.03809C11.4873 6.07551 11.8937 6.15471 12.2705 6.34668L12.4883 6.46875C12.984 6.7728 13.3878 7.20854 13.6533 7.72949L13.7197 7.87207C13.8642 8.20859 13.9292 8.56974 13.9619 8.9707C13.9987 9.42092 13.998 9.97799 13.998 10.667V12.665ZM18.165 9.33301C18.165 10.022 18.1657 10.5791 18.1289 11.0293C18.0961 11.4302 18.0311 11.7914 17.8867 12.1279L17.8203 12.2705C17.5549 12.7914 17.1509 13.2272 16.6553 13.5313L16.4365 13.6533C16.0599 13.8452 15.6541 13.9245 15.1963 13.9619C14.8593 13.9895 14.4624 13.9935 13.9951 13.9951C13.9935 14.4624 13.9895 14.8593 13.9619 15.1963C13.9292 15.597 13.864 15.9576 13.7197 16.2939L13.6533 16.4365C13.3878 16.9576 12.9841 17.3941 12.4883 17.6982L12.2705 17.8203C11.8937 18.0123 11.4873 18.0915 11.0293 18.1289C10.5791 18.1657 10.022 18.165 9.33301 18.165H6.5C5.81091 18.165 5.25395 18.1657 4.80371 18.1289C4.40306 18.0962 4.04235 18.031 3.70606 17.8867L3.56348 17.8203C3.04244 17.5548 2.60585 17.151 2.30176 16.6553L2.17969 16.4365C1.98788 16.0599 1.90851 15.6541 1.87109 15.1963C1.83431 14.746 1.83496 14.1891 1.83496 13.5V10.667C1.83496 9.978 1.83432 9.42091 1.87109 8.9707C1.90851 8.5127 1.98772 8.10625 2.17969 7.72949L2.30176 7.51172C2.60586 7.0159 3.04236 6.6122 3.56348 6.34668L3.70606 6.28027C4.04237 6.136 4.40303 6.07083 4.80371 6.03809C5.14051 6.01057 5.53708 6.00551 6.00391 6.00391C6.00551 5.53708 6.01057 5.14051 6.03809 4.80371C6.0755 4.34588 6.15483 3.94012 6.34668 3.56348L6.46875 3.34473C6.77282 2.84912 7.20856 2.44514 7.72949 2.17969L7.87207 2.11328C8.20855 1.96886 8.56979 1.90385 8.9707 1.87109C9.42091 1.83432 9.978 1.83496 10.667 1.83496H13.5C14.1891 1.83496 14.746 1.83431 15.1963 1.87109C15.6541 1.90851 16.0599 1.98788 16.4365 2.17969L16.6553 2.30176C17.151 2.60585 17.5548 3.04244 17.8203 3.56348L17.8867 3.70606C18.031 4.04235 18.0962 4.40306 18.1289 4.80371C18.1657 5.25395 18.165 5.81091 18.165 6.5V9.33301Z"></path></svg></button></span></div></div></div></div>
<p data-start="1925" data-end="2060">I applied this mapping across all rules by looking up each <code data-start="1984" data-end="1991">logid</code> in Fortinet’s reference and adjusting the <code data-start="2034" data-end="2043">&lt;level&gt;</code> tag accordingly with the help of a python script. I’ve mapped the Fortinet severities to Wazuh alert levels using a stricter scale to better reflect the risk profile of each log entry. The mapping favors the maximum in each Wazuh range for clear visibility. Where Fortinet severity is not explicitly defined (like debug or unknown types), I defaulted to level 4 for moderate visibility.</p>
<hr data-start="2062" data-end="2065">
<h3 data-start="2067" data-end="2101">Why This Improves the Ruleset:</h3>
<ul data-start="2102" data-end="2302">
<li data-start="2102" data-end="2178">
<p data-start="2104" data-end="2178">Provides <strong data-start="2113" data-end="2139">more accurate alerting</strong> in Wazuh based on real-world severity.</p>
</li>
<li data-start="2179" data-end="2240">
<p data-start="2181" data-end="2240">Helps <strong data-start="2187" data-end="2211">prioritize responses</strong> to critical Fortinet events.</p>
</li>
<li data-start="2241" data-end="2302">
<p data-start="2243" data-end="2302">Reduces alert fatigue by lowering levels for low-risk logs.</p>
</li>
</ul>
<hr data-start="2304" data-end="2307">
<h3 data-start="2309" data-end="2329">References Used:</h3>
<ul class="contains-task-list" data-start="2430" data-end="2654">
<li class="task-list-item" data-start="2430" data-end="2560">
<p data-start="2436" data-end="2560"><input disabled="" type="checkbox"> Fortinet Log Reference Documentation ( <code data-start="2480" data-end="2559">https://docs.fortinet.com/document/fortigate/7.6.3/fortios-log-message-reference</code>)</p>
</li>
</ul>
<hr data-start="2656" data-end="2659">
<h3 data-start="2661" data-end="2671">Notes:</h3>
<ul data-start="2672" data-end="2822">
<li data-start="2672" data-end="2745">
<p data-start="2674" data-end="2745">All changes were made to a single XML file: <code data-start="2718" data-end="2744">0391-fortigate_rules.xml</code>.</p>
</li>
<li data-start="2746" data-end="2793">
<p data-start="2748" data-end="2793">XML formatting and syntax has been preserved.</p>
</li>
<li data-start="2794" data-end="2822">
<p data-start="2796" data-end="2822">No decoders were modified.</p></li></ul><!--EndFragment-->
</body>
</html>